### PR TITLE
docs: add per-directory source documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ curl http://localhost:8788/api/v1/search?q=governance
 - [Specification](docs/spec.md) (v0.11) — Full architecture and API spec
 - [Implementation Plan](docs/plan.md) (v2.6) — Phased build plan
 - [CLAUDE.md](CLAUDE.md) — AI assistant context and code standards
+- **Source Documentation** (`docs/src/`) — Per-directory developer guides:
+  - [index.md](docs/src/index.md) — Entry point + routing
+  - [types.md](docs/src/types.md) — Type system + content ontology
+  - [auth.md](docs/src/auth.md) — Porch access control framework
+  - [mcp.md](docs/src/mcp.md) — MCP server (tools, resources, prompts)
+  - [api.md](docs/src/api.md) — REST API routes + OpenAPI
+  - [retrieval.md](docs/src/retrieval.md) — Three-stage search pipeline
+  - [sync.md](docs/src/sync.md) — GitHub sync workflow + markdown parsing
+  - [consumers.md](docs/src/consumers.md) — Queue consumer (R2 → Vectorize)
 
 ## Status
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,269 @@
+# API
+
+> Public read-only REST API built with Hono + OpenAPI, providing entry listing, single entry retrieval, and semantic search.
+
+**Source:** `src/api/`
+**Files:** 2 (`routes.ts`, `schemas.ts`)
+**Spec reference:** `docs/spec.md` sections 8, 10
+**Depends on:** `types` (`ContentTypeSchema`, `ListParamsSchema`, `SearchParamsSchema`, response schemas), `retrieval` (`searchKnowledge`), `types/storage` (`toR2Key`, `R2Document`)
+**Depended on by:** `index` (mounted at `/api/v1` via Hono routing)
+
+---
+
+## Overview
+
+The API module provides a public REST API for the knowledge base, designed for web frontends and external integrations that don't use MCP. It exposes three routes plus an auto-generated OpenAPI spec, all read-only, all unauthenticated (Phase 1).
+
+The API is built with `@hono/zod-openapi`, which combines Hono's routing with Zod schema validation and automatic OpenAPI 3.1 document generation. Route parameters and responses are validated at runtime and documented in the generated spec at `/api/v1/openapi.json`.
+
+CORS is configured for universal access (`origin: '*'`, GET/HEAD/OPTIONS only). All GET responses include cache headers (`public, max-age=300, stale-while-revalidate=3600`) for CDN and browser caching.
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    Client["Web Client /<br/>External Service"] -->|GET| Hono["Hono Router<br/>/api/v1/*"]
+
+    Hono --> CORS["CORS Middleware<br/>origin: *"]
+    CORS --> List["GET /entries<br/>R2 full-scan + paginate"]
+    CORS --> Get["GET /entries/:type/:id<br/>R2 direct lookup"]
+    CORS --> Search["GET /search<br/>searchKnowledge()"]
+    CORS --> OAS["GET /openapi.json<br/>Auto-generated"]
+
+    List --> R2["R2 Bucket<br/>(KNOWLEDGE)"]
+    Get --> R2
+    Search --> Retrieval["src/retrieval/<br/>3-stage pipeline"]
+    Retrieval --> R2
+    Retrieval --> AI["Workers AI"]
+    Retrieval --> Vec["Vectorize"]
+```
+
+## File-by-File Reference
+
+### `routes.ts`
+
+**Purpose:** Defines the Hono app with three API routes and the OpenAPI spec endpoint.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `api` | `OpenAPIHono` instance | `OpenAPIHono<{ Bindings: Env }>` | The Hono app, mounted by `src/index.ts` at `/api/v1` |
+
+#### Internal Logic
+
+**App setup:**
+- Uses `OpenAPIHono` (not plain `Hono`) for automatic OpenAPI generation
+- Global error handler returns `{ error: { code: 'INTERNAL_ERROR', message: '...' } }` with 500 status
+- CORS middleware: `origin: '*'`, methods: `GET, HEAD, OPTIONS`, headers: `Content-Type, Accept`, max-age: 86400 (24h preflight cache)
+- Cache headers constant: `Cache-Control: public, max-age=300, stale-while-revalidate=3600`
+
+---
+
+**`GET /entries` — List/filter entries**
+
+Query parameters (validated by `ListQuerySchema`):
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `contentType` | ContentType | (none) | Filter by content type |
+| `group` | string | (none) | Filter by group metadata |
+| `release` | string | (none) | Filter by release metadata |
+| `limit` | number | 20 | Page size (1-100) |
+| `offset` | number | 0 | Pagination offset |
+
+Response: `{ data: R2Document[], total: number, offset: number, limit: number }`
+
+Algorithm:
+1. Build R2 list prefix: `content/{contentType}/` if filtered, `content/` otherwise
+2. Paginate through R2 listing using cursor (handles truncated results with `limit: 1000` per page)
+3. Batch-fetch all R2 objects in parallel via `Promise.all()`
+4. Filter by `group` and `release` metadata (post-fetch filtering)
+5. Calculate `total` from filtered count
+6. Slice for pagination: `entries.slice(offset, offset + limit)`
+
+**Performance note:** This route does a full R2 scan — it lists ALL objects under the prefix, fetches ALL of them, then paginates in memory. This works for the current dataset size but would need optimization (e.g., a metadata index in KV) for thousands of documents.
+
+---
+
+**`GET /entries/{contentType}/{id}` — Single entry**
+
+Path parameters (validated by `EntryParamsSchema`):
+| Param | Type | Description |
+|-------|------|-------------|
+| `contentType` | ContentType | Content type |
+| `id` | string (min 1) | Document ID |
+
+Responses:
+- 200: `{ data: R2Document }`
+- 404: `{ error: { code: 'NOT_FOUND', message: 'Entry {type}/{id} not found' } }`
+
+Algorithm:
+1. Construct R2 key using `toR2Key(contentType, id)`
+2. Fetch from R2
+3. Return 404 if not found, 200 with document if found
+
+---
+
+**`GET /search` — Semantic search**
+
+Query parameters (validated by `SearchQuerySchema`):
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `q` | string (required) | | Search query |
+| `contentType` | ContentType | (none) | Filter by content type |
+| `group` | string | (none) | Filter by group |
+| `release` | string | (none) | Filter by release |
+| `limit` | number | 5 | Max results (1-20) |
+
+Response: `{ results: SearchResult[] }`
+
+Algorithm:
+1. Delegates to `searchKnowledge()` from the retrieval module
+2. Passes `{ contentType, group, release }` as filters
+3. Does NOT request `includeDocuments` (lightweight results only)
+4. Slices results to the requested `limit`
+
+---
+
+**`GET /openapi.json` — OpenAPI spec**
+
+Auto-generated by `@hono/zod-openapi` from route definitions and Zod schemas.
+
+```json
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SuperBenefit Knowledge API",
+    "version": "0.1.0",
+    "description": "Public read-only API for the SuperBenefit knowledge base"
+  }
+}
+```
+
+#### Dependencies
+- **Internal:** `./schemas`, `../types/storage` (toR2Key, R2Document), `../retrieval` (searchKnowledge)
+- **External:** `@hono/zod-openapi` (OpenAPIHono, createRoute), `hono/cors`
+
+---
+
+### `schemas.ts`
+
+**Purpose:** Route-level parameter schemas and re-exports of response schemas for OpenAPI generation.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `EntryParamsSchema` | Zod object | Path params: `{ contentType: ContentType, id: string }` with OpenAPI param annotations |
+| `ListQuerySchema` | Zod object | `ListParamsSchema` with `.openapi('ListQuery')` |
+| `SearchQuerySchema` | Zod object | `SearchParamsSchema` with `.openapi('SearchQuery')` |
+| `EntryListResponseSchema` | Re-export | From `types/api.ts` |
+| `EntryResponseSchema` | Re-export | From `types/api.ts` |
+| `SearchResponseSchema` | Re-export | From `types/api.ts` |
+| `ErrorResponseSchema` | Re-export | From `types/api.ts` |
+
+#### Internal Logic
+
+The `EntryParamsSchema` adds OpenAPI parameter metadata (`{ param: { name, in: 'path' } }`) to the content type and ID fields. This enables proper path parameter documentation in the generated OpenAPI spec.
+
+`ListQuerySchema` and `SearchQuerySchema` are thin wrappers that add `.openapi()` names to the existing type schemas, enabling them to appear as named components in the OpenAPI spec.
+
+Response schemas are re-exported unchanged — they already have `.openapi()` annotations from `types/api.ts`.
+
+#### Dependencies
+- **Internal:** `../types/content` (ContentTypeSchema), `../types/api` (ListParamsSchema, SearchParamsSchema, response schemas)
+- **External:** `@hono/zod-openapi`
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `R2Document` | `types/storage.ts` | Document shape returned in responses |
+| `ListParams` | `types/api.ts` | Validated query params for listing |
+| `SearchParams` | `types/api.ts` | Validated query params for search |
+| `SearchResult` | `types/api.ts` | Search result shape |
+| `ContentType` | `types/content.ts` | Valid content type for path/query params |
+
+See [types.md](types.md) for full definitions.
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `KNOWLEDGE` | `R2Bucket` | List entries, get entries |
+| `AI` | `Ai` | Via `searchKnowledge()` — embedding + reranking |
+| `VECTORIZE` | `VectorizeIndex` | Via `searchKnowledge()` — similarity search |
+| `RERANK_CACHE` | `KVNamespace` | Via `searchKnowledge()` — reranker cache |
+
+## Configuration and Limits
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| CORS origin | `*` | `routes.ts` |
+| CORS methods | `GET, HEAD, OPTIONS` | `routes.ts` |
+| CORS preflight max-age | 86400 (24h) | `routes.ts` |
+| Cache-Control | `public, max-age=300, stale-while-revalidate=3600` | `routes.ts` |
+| List limit range | 1-100 (default 20) | `types/api.ts` |
+| Search limit range | 1-20 (default 5) | `types/api.ts` |
+| R2 list page size | 1000 (Cloudflare max) | `routes.ts` |
+
+## Error Handling
+
+| Failure | Response |
+|---------|----------|
+| Validation error (bad params) | 400 with Zod error details (via `@hono/zod-openapi`) |
+| Entry not found | 404: `{ error: { code: 'NOT_FOUND', message: '...' } }` |
+| Unhandled exception | 500: `{ error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' } }` |
+| CORS preflight | 204 with appropriate headers (via Hono CORS middleware) |
+
+## Example Requests
+
+```bash
+# List all entries
+curl http://localhost:8788/api/v1/entries
+
+# List patterns only
+curl http://localhost:8788/api/v1/entries?contentType=pattern
+
+# List with pagination
+curl http://localhost:8788/api/v1/entries?limit=10&offset=20
+
+# Get a specific entry
+curl http://localhost:8788/api/v1/entries/pattern/cell-governance
+
+# Semantic search
+curl 'http://localhost:8788/api/v1/search?q=governance+patterns'
+
+# Search with filters
+curl 'http://localhost:8788/api/v1/search?q=coordination&contentType=practice&limit=3'
+
+# OpenAPI spec
+curl http://localhost:8788/api/v1/openapi.json
+
+# CORS preflight
+curl -I -X OPTIONS http://localhost:8788/api/v1/entries \
+  -H "Origin: https://example.com" \
+  -H "Access-Control-Request-Method: GET"
+```
+
+## Extension Points
+
+**Adding a new API route:**
+1. Define query/path param schemas in `schemas.ts` using `@hono/zod-openapi`
+2. Create the route definition with `createRoute()` in `routes.ts`
+3. Implement the handler with `api.openapi(route, handler)`
+4. Response schemas are automatically included in the OpenAPI spec
+
+**Adding authentication (Phase 2):**
+1. Add a Hono middleware that reads the `CF-Access-Jwt-Assertion` header
+2. Call `resolveAuthContext()` to determine the tier
+3. Apply the middleware to routes that require authentication
+
+## Cross-References
+
+- [types.md](types.md) — `ListParams`, `SearchParams`, `SearchResult`, `R2Document`, `ErrorResponse`
+- [retrieval.md](retrieval.md) — `searchKnowledge()` pipeline used by the search route
+- [index.md](index.md) — Where the API is mounted at `/api/v1`
+- `docs/spec.md` sections 8, 10 — REST API and error handling specification

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -1,0 +1,190 @@
+# Auth
+
+> Implements the porch access control framework — a three-tier authorization model that gates tool and resource access.
+
+**Source:** `src/auth/`
+**Files:** 3 (`index.ts`, `resolve.ts`, `check.ts`)
+**Spec reference:** `docs/spec.md` section 2
+**Depends on:** `types` (`types/auth.ts`)
+**Depended on by:** `mcp` (every tool calls both functions)
+
+---
+
+## Overview
+
+The auth directory implements the "porch" access control framework — a metaphor for the layers of access to a house: the porch (open/public), the living room (public/authenticated), and private rooms (members). In Phase 1, the entire system operates at the porch level: all requests are anonymous and all tools are open.
+
+The design is deliberately simple now but structured for evolution. Two functions form the entire API surface: `resolveAuthContext()` determines *who* is making the request and *what tier* they have, while `checkTierAccess()` determines *whether* that tier is sufficient for a given operation. Tools never resolve tiers themselves — they call these two functions and act on the result.
+
+The `_env` parameter on `resolveAuthContext()` exists now (even though Phase 1 doesn't use it) because Phase 2 will need it to parse Cloudflare Access JWTs from the environment.
+
+## Data Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant Tool as MCP Tool / API Route
+    participant Resolve as resolveAuthContext()
+    participant Check as checkTierAccess()
+
+    Tool->>Resolve: resolve(env)
+    Note over Resolve: Phase 1: return { identity: null, tier: 'open' }
+    Note over Resolve: Phase 2: parse CF Access JWT → public tier
+    Note over Resolve: Phase 3: check Hats Protocol → members tier
+    Resolve-->>Tool: AuthContext
+
+    Tool->>Check: check('open', authContext)
+    alt Tier sufficient
+        Check-->>Tool: { allowed: true, authContext }
+    else Tier insufficient
+        Check-->>Tool: { allowed: false, requiredTier, currentTier }
+    end
+```
+
+## File-by-File Reference
+
+### `index.ts`
+
+**Purpose:** Barrel file re-exporting the two public functions.
+
+#### Exports
+
+| Export | Kind | Source |
+|--------|------|--------|
+| `resolveAuthContext` | Function | `./resolve` |
+| `checkTierAccess` | Function | `./check` |
+
+---
+
+### `resolve.ts`
+
+**Purpose:** Resolves the access context (identity + tier) for the current request.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `resolveAuthContext` | Async function | `(_env: Env) => Promise<AuthContext>` | Returns the resolved auth context |
+
+#### Internal Logic
+
+**Phase 1 implementation:** Always returns `{ identity: null, tier: 'open' }`. The function is async and accepts `_env` (underscore-prefixed, unused) to maintain the interface contract for future phases.
+
+**Phase 2 extension path:**
+1. Read the `CF-Access-Jwt-Assertion` header from the request
+2. Verify the JWT against `env.CF_ACCESS_AUD` (already declared in `env.d.ts` as optional)
+3. Extract user identity from JWT claims
+4. Return `{ identity: { userId, name, email, provider: 'github' }, tier: 'public' }`
+
+**Phase 3 extension path:**
+1. After Phase 2 JWT verification, extract the user's Ethereum address
+2. Call Hats Protocol contract on Optimism to check hat ownership
+3. If the user wears the required hat, return `tier: 'members'`
+
+#### Dependencies
+- **Internal:** `../types/auth` (AuthContext type)
+
+---
+
+### `check.ts`
+
+**Purpose:** Checks whether an auth context meets a required access tier.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `checkTierAccess` | Function | `(requiredTier: AccessTier, authContext: AuthContext) => TierAccessResult` | Pure synchronous tier comparison |
+
+#### Internal Logic
+
+Uses `TIER_LEVEL` numeric ordering for comparison:
+
+```
+open (0) < public (1) < members (2)
+```
+
+Returns a discriminated union result:
+- `{ allowed: true, authContext }` — access granted, includes the auth context for downstream use (e.g., extracting `identity.userId`)
+- `{ allowed: false, requiredTier, currentTier }` — access denied, includes both tiers for error messaging
+
+The `TierAccessResult` type is defined locally (not exported from types) as:
+
+```typescript
+type TierAccessResult =
+  | { allowed: true; authContext: AuthContext }
+  | { allowed: false; requiredTier: AccessTier; currentTier: AccessTier };
+```
+
+This discriminated union pattern allows callers to narrow the type after checking `allowed`:
+
+```typescript
+const access = checkTierAccess('open', authContext);
+if (!access.allowed) {
+  // TypeScript knows: access.requiredTier, access.currentTier
+  return errorResponse(access.requiredTier);
+}
+// TypeScript knows: access.authContext
+const userId = access.authContext.identity?.userId;
+```
+
+#### Dependencies
+- **Internal:** `../types/auth` (AccessTier, AuthContext, TIER_LEVEL)
+
+---
+
+## Key Types
+
+| Type | Defined In | Description |
+|------|-----------|-------------|
+| `AccessTier` | `types/auth.ts` | `'open' \| 'public' \| 'members'` |
+| `AuthContext` | `types/auth.ts` | `{ identity: Identity \| null, tier: AccessTier }` |
+| `Identity` | `types/auth.ts` | `{ userId, name, email, provider }` |
+| `TIER_LEVEL` | `types/auth.ts` | `{ open: 0, public: 1, members: 2 }` |
+| `TierAccessResult` | `check.ts` (local) | Discriminated union on `allowed` |
+
+See [types.md](types.md) for full type definitions.
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `CF_ACCESS_AUD` | `string?` | Phase 2: Cloudflare Access audience tag for JWT verification |
+
+Phase 1 uses no bindings. The `env` parameter is accepted but unused.
+
+## Error Handling
+
+The auth module itself never throws. `resolveAuthContext()` returns a valid context in all cases (Phase 1 always returns open tier). `checkTierAccess()` is a pure function that returns a result union — callers check `allowed` and handle denial themselves.
+
+When access is denied, MCP tools return:
+```json
+{
+  "content": [{ "type": "text", "text": "Requires members access. Current: open." }],
+  "isError": true
+}
+```
+
+## Extension Points
+
+**Adding a new access tier:**
+1. Add the tier to the `AccessTier` type and `AccessTierSchema` in `types/auth.ts`
+2. Add its numeric level to `TIER_LEVEL` (higher = more privileged)
+3. Add resolution logic to `resolveAuthContext()` in `resolve.ts`
+4. No changes needed to `checkTierAccess()` — it works with any tier
+
+**Upgrading a tool's tier (e.g., Phase 3 Members):**
+1. In `src/mcp/tools.ts`, change the `checkTierAccess('open', ...)` call to `checkTierAccess('members', ...)`
+2. No other changes needed — the auth module handles the rest
+
+**Phase 2 implementation checklist:**
+1. Set `CF_ACCESS_AUD` secret via `wrangler secret put`
+2. Update `resolveAuthContext()` to read and verify the Access JWT
+3. Map JWT claims to `Identity` fields
+4. Return `tier: 'public'` for valid JWTs, `tier: 'open'` otherwise
+
+## Cross-References
+
+- [types.md](types.md) — `AccessTier`, `AuthContext`, `Identity` type definitions
+- [mcp.md](mcp.md) — How tools use the guard pattern with `resolveAuthContext()` + `checkTierAccess()`
+- `CLAUDE.md` — Guard boilerplate snippet
+- `docs/spec.md` section 2 — Full porch access control specification

--- a/docs/src/consumers.md
+++ b/docs/src/consumers.md
@@ -1,0 +1,183 @@
+# Consumers
+
+> Processes R2 bucket event notifications via a queue consumer to keep Vectorize in sync with stored content.
+
+**Source:** `src/consumers/`
+**Files:** 1 (`vectorize.ts`)
+**Spec reference:** `docs/spec.md` sections 4.3-4.4, 5.3
+**Depends on:** `types` (`VectorizeMetadata`, `R2Document`, `extractIdFromKey`, `truncateForMetadata`, `toR2Key`, `VECTORIZE_NAMESPACE`)
+**Depended on by:** `index` (exports `handleVectorizeQueue` for the worker's `queue` handler)
+
+---
+
+## Overview
+
+The consumers directory contains a single queue consumer that bridges R2 storage and Vectorize search. When the sync workflow writes or deletes a document in R2, the R2 bucket emits an event notification to a Cloudflare Queue. This consumer processes those events, generating embeddings for new/updated documents and removing vectors for deleted ones.
+
+This is the write-side counterpart to the [retrieval module](retrieval.md)'s read-side search pipeline. Together they form a complete index: sync writes to R2, R2 events trigger this consumer, the consumer writes to Vectorize, and the retrieval module reads from Vectorize.
+
+The consumer is designed for idempotency — upserting the same document ID overwrites the previous vector, and deleting a non-existent ID is a no-op. This is critical because R2 event notifications have no ordering guarantee.
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    R2["R2 Bucket<br/>(KNOWLEDGE)"] -->|event notification| Queue["Cloudflare Queue<br/>(superbenefit-knowledge-sync)"]
+    Queue --> Consumer["handleVectorizeQueue()"]
+
+    Consumer -->|object-create| Fetch["R2.get(key)"]
+    Fetch --> Parse["Parse R2Document JSON"]
+    Parse --> Embed["AI.run()<br/>@cf/baai/bge-base-en-v1.5"]
+    Embed --> Upsert["Vectorize.upsert()<br/>id, values, metadata"]
+
+    Consumer -->|object-delete| Delete["Vectorize.deleteByIds()"]
+
+    Consumer -->|not content/| Skip["msg.ack()<br/>(skip)"]
+```
+
+## File-by-File Reference
+
+### `vectorize.ts`
+
+**Purpose:** Queue consumer that processes R2 event notifications to update the Vectorize index.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `handleVectorizeQueue` | Async function | `(batch: MessageBatch<R2EventNotification>, env: ConsumerDeps) => Promise<void>` | Main queue handler |
+| `updateVectorize` | Async function | `(doc: R2Document, env: Pick<ConsumerDeps, 'AI' \| 'VECTORIZE'>) => Promise<void>` | Upsert a document into Vectorize |
+| `deleteFromVectorize` | Async function | `(id: string, env: Pick<ConsumerDeps, 'VECTORIZE'>) => Promise<void>` | Delete a vector by ID |
+
+#### Internal Logic
+
+**`handleVectorizeQueue()`:**
+
+Iterates through each message in the batch sequentially. For each message:
+
+1. **Prefix filter:** Checks if `object.key` starts with `content/`. Non-content objects (e.g., metadata files) are acknowledged and skipped.
+2. **Create events (`object-create`):**
+   - Fetches the R2 object by key
+   - If the object is gone (deleted between event and processing), acknowledges and skips
+   - Parses the R2 object as `R2Document` JSON
+   - Calls `updateVectorize()` to embed and upsert
+3. **Delete events (`object-delete`):**
+   - Extracts the document ID from the R2 key using `extractIdFromKey()`
+   - Calls `deleteFromVectorize()` to remove the vector
+4. **Acknowledgment:** `msg.ack()` is called per-message on success. On failure, the message is NOT acknowledged, so the queue will retry it.
+
+**Per-message `msg.ack()` is critical.** The codebase explicitly avoids `batch.ackAll()` — if one message fails, only that message should be retried, not the entire batch.
+
+**`updateVectorize()`:**
+
+1. **Build embedding input:** Concatenates `title`, `description`, and `content` body (filtered for truthy values, joined with double newlines)
+2. **Generate embedding:** Calls `@cf/baai/bge-base-en-v1.5` via Workers AI, producing a 768-dimensional vector
+3. **Build metadata:** Constructs a `VectorizeMetadata` object with:
+   - 6 indexed fields: `contentType`, `group`, `tags` (comma-joined from array), `release`, `status`, `date` (Unix timestamp ms)
+   - 4 non-indexed fields: `path` (R2 key), `title`, `description`, `content` (truncated to ~8KB via `truncateForMetadata()`)
+4. **Upsert:** Calls `VECTORIZE.upsert()` with the vector ID, values, metadata, and namespace
+
+**Metadata construction details:**
+- `tags` are serialized as a comma-separated string because Vectorize metadata values must be scalar. The search module uses `$in` filter semantics to match.
+- `date` is stored as a Unix timestamp (milliseconds) for numeric range filtering.
+- `content` is truncated to ~8000 characters at a word boundary to stay within the 10 KiB metadata limit while leaving room for other fields.
+- Missing optional fields default to empty string `''` or `0` for date.
+
+**`deleteFromVectorize()`:**
+- Calls `VECTORIZE.deleteByIds([id])` — idempotent, no error on missing IDs.
+
+#### Internal Types
+
+**`R2EventNotification`** (defined locally, mirrors `types/sync.ts`):
+```typescript
+interface R2EventNotification {
+  account: string;
+  bucket: string;
+  object: { key: string; size: number; eTag: string };
+  eventType: 'object-create' | 'object-delete';
+  eventTime: string;
+}
+```
+
+**`ConsumerDeps`** (dependency injection interface):
+```typescript
+interface ConsumerDeps {
+  KNOWLEDGE: R2Bucket;
+  VECTORIZE: VectorizeIndex;
+  AI: Ai;
+}
+```
+
+The `ConsumerDeps` interface abstracts bindings for testability. `updateVectorize()` and `deleteFromVectorize()` accept `Pick<>` subsets to declare their minimum requirements.
+
+#### Dependencies
+- **Internal:** `../types/storage` (extractIdFromKey, truncateForMetadata, toR2Key, VECTORIZE_NAMESPACE), `../types` (VectorizeMetadata, R2Document)
+- **External:** Cloudflare Workers AI (`env.AI`), Cloudflare Vectorize (`env.VECTORIZE`), Cloudflare R2 (`env.KNOWLEDGE`)
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `R2Document` | `types/storage.ts` | Document read from R2, input to `updateVectorize()` |
+| `VectorizeMetadata` | `types/storage.ts` | Metadata attached to each vector (10 fields, 6 indexed) |
+| `R2EventNotification` | `vectorize.ts` (local) | R2 bucket event payload |
+| `ConsumerDeps` | `vectorize.ts` (local) | Binding interface for dependency injection |
+
+See [types.md](types.md) for full schema definitions.
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `KNOWLEDGE` | `R2Bucket` | Fetch document JSON on create events |
+| `AI` | `Ai` | Generate BGE embeddings for documents |
+| `VECTORIZE` | `VectorizeIndex` | Upsert and delete vectors |
+
+## Configuration and Limits
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| Queue name | `superbenefit-knowledge-sync` | `wrangler.jsonc` |
+| Max batch size | 10 | `wrangler.jsonc` |
+| Max batch timeout | 30 seconds | `wrangler.jsonc` |
+| Embedding model | `@cf/baai/bge-base-en-v1.5` | Application code |
+| Vectorize namespace | `'superbenefit'` | `VECTORIZE_NAMESPACE` constant |
+| Content prefix | `content/` | Application code |
+| Max metadata content | 8,000 chars | `truncateForMetadata()` in `types/storage.ts` |
+
+## Error Handling
+
+| Failure | Behavior |
+|---------|----------|
+| R2 object missing on create | Acknowledged and skipped (object deleted between event and processing) |
+| Embedding generation fails | Exception logged, message NOT acknowledged (queue retries) |
+| Vectorize upsert fails | Exception logged, message NOT acknowledged (queue retries) |
+| Vectorize delete fails | Exception logged, message NOT acknowledged (queue retries) |
+| Non-content/ key | Acknowledged and skipped (not our concern) |
+
+The error logging includes the message ID for debugging:
+```
+Failed to process queue message {msg.id}: {error.message}
+```
+
+## Extension Points
+
+**Adding new indexed metadata fields:**
+1. Add the field to `VectorizeMetadataSchema` in `types/storage.ts`
+2. Populate it in the metadata construction block of `updateVectorize()`
+3. Create the metadata index: `wrangler vectorize create-metadata-index superbenefit-knowledge-idx --property-name=fieldName --type=string`
+4. Count total indexed fields (max 10; currently 6)
+
+**Processing additional event types:**
+1. Extend the `eventType` union in `R2EventNotification`
+2. Add a new branch in the event processing loop in `handleVectorizeQueue()`
+
+## Cross-References
+
+- [types.md](types.md) — `R2Document`, `VectorizeMetadata` schemas
+- [retrieval.md](retrieval.md) — The read-side counterpart that queries the Vectorize index
+- [sync.md](sync.md) — The workflow that writes to R2, triggering the events this consumer processes
+- [index.md](index.md) — Where `handleVectorizeQueue` is wired to the worker's `queue` export
+- `docs/spec.md` sections 4.3-4.4, 5.3 — Vectorize indexing and event processing specification

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,211 @@
+# Index (Entry Point)
+
+> Main worker entry point — routes requests across MCP, REST API, and GitHub webhooks, and exports the queue consumer.
+
+**Source:** `src/index.ts`, `src/env.d.ts`
+**Files:** 2
+**Spec reference:** `docs/spec.md` sections 1, 5.1, 8, 9
+**Depends on:** `api` (Hono app), `mcp` (McpHandler), `consumers` (handleVectorizeQueue), `sync` (verifyWebhookSignature, isExcluded, KnowledgeSyncWorkflow), `types` (GitHubPushEvent)
+**Depended on by:** Cloudflare Workers runtime (worker entry point)
+
+---
+
+## Overview
+
+The index module is the single entry point for the Cloudflare Worker. It handles two runtime entrypoints: `fetch` (HTTP requests) and `queue` (queue message batches). The fetch handler implements a three-way routing split that directs requests to specialized handlers before they reach Hono's general-purpose router.
+
+The routing split is intentional — MCP requests bypass Hono entirely to avoid middleware interference (MCP uses SSE and has its own CORS handling), while the REST API benefits from Hono's middleware stack (CORS, validation, OpenAPI generation). The webhook handler is also routed directly to avoid unnecessary middleware processing.
+
+The file also contains the `handleWebhook()` function, which validates GitHub push events and triggers the sync workflow. Finally, it re-exports `KnowledgeSyncWorkflow` at the module level so Cloudflare's runtime can discover it via the `class_name` configuration in `wrangler.jsonc`.
+
+## Data Flow Diagram
+
+```mermaid
+graph TD
+    Request["Incoming Request"] --> Fetch["export default { fetch }"]
+
+    Fetch -->|"/mcp" or "/mcp/*"| MCP["McpHandler.fetch()<br/>Direct — bypasses Hono"]
+    Fetch -->|"POST /webhook"| WH["handleWebhook()<br/>Direct — bypasses Hono"]
+    Fetch -->|everything else| Hono["Hono Router"]
+
+    Hono -->|"/api/v1/*"| API["api routes<br/>(see api.md)"]
+    Hono -->|unmatched| 404["Hono 404"]
+
+    WH --> Verify["verifyWebhookSignature()"]
+    Verify -->|invalid| R403["403 Invalid signature"]
+    Verify -->|valid| Branch{"ref === refs/heads/main?"}
+    Branch -->|no| Ignore["{ status: 'ignored' }"]
+    Branch -->|yes| Collect["Collect .md files<br/>filter excluded<br/>deduplicate"]
+    Collect --> Trigger["env.SYNC_WORKFLOW.create()"]
+
+    Queue["Queue Messages"] --> QueueHandler["export default { queue }<br/>handleVectorizeQueue()"]
+```
+
+## File-by-File Reference
+
+### `index.ts`
+
+**Purpose:** Main worker module — HTTP routing, webhook handling, and runtime exports.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `KnowledgeSyncWorkflow` | Re-export (class) | From `./sync/workflow` — required for wrangler class_name discovery |
+| `default` | Object | `{ fetch, queue }` — Worker module entry point |
+
+#### Internal Logic
+
+**`fetch` handler — Three-way routing split:**
+
+```
+Request URL pathname
+├── /mcp or /mcp/* → McpHandler.fetch(request, env, ctx)
+├── POST /webhook  → handleWebhook(request, env)
+└── *              → app.fetch(request, env, ctx)  (Hono)
+```
+
+1. **MCP path** (`/mcp` or `/mcp/*`): Delegates directly to `McpHandler.fetch()`, bypassing Hono. This is critical because MCP uses its own transport (SSE/Streamable HTTP) and CORS configuration.
+
+2. **Webhook path** (`POST /webhook`): Delegates to `handleWebhook()` for GitHub push event processing.
+
+3. **Everything else**: Goes through Hono, which mounts the REST API at `/api/v1`.
+
+**`queue` handler:**
+
+Set to `handleVectorizeQueue` from `src/consumers/vectorize.ts`. Processes R2 event notifications from the queue.
+
+**Hono app setup:**
+
+```typescript
+const app = new Hono<{ Bindings: Env }>();
+app.route('/api/v1', api);
+```
+
+The Hono app is minimal — it only mounts the API sub-application. All middleware (CORS, error handling) is defined within the API module itself.
+
+---
+
+**`handleWebhook()` — GitHub push event processing:**
+
+1. **Read body:** `await request.text()` (needed for both signature verification and JSON parsing)
+2. **Verify signature:** Reads `x-hub-signature-256` header, calls `verifyWebhookSignature()`. Returns 403 if invalid.
+3. **Parse payload:** `JSON.parse(body)` as `GitHubPushEvent`
+4. **Branch filter:** Only processes pushes to `refs/heads/main`. Returns `{ status: 'ignored', reason: 'not main branch' }` otherwise.
+5. **Collect files:**
+   - Changed files: flattens `added` + `modified` from all commits, filters for `.md` extension and not excluded
+   - Deleted files: flattens `removed` from all commits, filters for `.md` extension
+   - Note: deleted files are NOT filtered through `isExcluded()` (excluded files that were previously synced should still be deletable)
+6. **Deduplicate:** Uses `Set` to remove duplicates (a file may appear in multiple commits within the same push)
+7. **Short-circuit:** If no markdown files changed, returns `{ status: 'ignored', reason: 'no markdown files changed' }`
+8. **Trigger workflow:** `env.SYNC_WORKFLOW.create({ params: { changedFiles, deletedFiles, commitSha } })`
+9. **Response:** `{ status: 'ok', changed: N, deleted: N }`
+
+#### Dependencies
+- **Internal:** `./api/routes` (api), `./mcp` (McpHandler), `./consumers/vectorize` (handleVectorizeQueue), `./sync/github` (verifyWebhookSignature, isExcluded), `./types/sync` (GitHubPushEvent), `./sync/workflow` (KnowledgeSyncWorkflow — re-export)
+- **External:** `hono` (Hono)
+
+---
+
+### `env.d.ts`
+
+**Purpose:** TypeScript declarations for Cloudflare Worker environment bindings, extending both the `Cloudflare.Env` namespace and the global `Env` interface.
+
+#### Internal Logic
+
+The file contains **two parallel declarations** of the same bindings:
+
+1. **`declare namespace Cloudflare { interface Env { ... } }`** — Used by `cloudflare:workers` imports (e.g., `WorkflowEntrypoint<Env, ...>`). This is the Cloudflare SDK's convention.
+
+2. **`interface Env { ... }`** — Used by Hono's `Bindings` type parameter and by functions that accept `env: Env` directly.
+
+Both declarations are identical and must be kept in sync. This dual-declaration pattern is necessary because the Cloudflare SDK and Hono use different type resolution mechanisms.
+
+#### Complete Binding Inventory
+
+| Binding | Type | Category | Set Via | Description |
+|---------|------|----------|---------|-------------|
+| `GITHUB_TOKEN` | `string` | Secret | `wrangler secret put` | GitHub API authentication for file fetching |
+| `GITHUB_WEBHOOK_SECRET` | `string` | Secret | `wrangler secret put` | HMAC-SHA256 key for webhook verification |
+| `GITHUB_REPO` | `string` | Secret | `wrangler secret put` | Repository in `owner/repo` format |
+| `RERANK_CACHE` | `KVNamespace` | KV | `wrangler.jsonc` | Caches reranker results (1-hour TTL) |
+| `SYNC_STATE` | `KVNamespace` | KV | `wrangler.jsonc` | Sync state tracking (reserved for future use) |
+| `KNOWLEDGE` | `R2Bucket` | R2 | `wrangler.jsonc` | Content storage (`content/{type}/{id}.json`) |
+| `VECTORIZE` | `VectorizeIndex` | Vectorize | `wrangler.jsonc` | Semantic search index |
+| `AI` | `Ai` | AI | `wrangler.jsonc` | Workers AI (BGE embedding + reranking) |
+| `SYNC_WORKFLOW` | `Workflow` | Workflow | `wrangler.jsonc` | GitHub sync workflow trigger |
+| `CF_ACCESS_AUD` | `string?` | Secret | Phase 2 | Cloudflare Access audience tag (optional, unused in Phase 1) |
+
+#### Dependencies
+- **External:** Cloudflare Workers runtime types (global)
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `Env` | `env.d.ts` | All Cloudflare bindings |
+| `GitHubPushEvent` | `types/sync.ts` | Webhook payload shape |
+
+## Cloudflare Bindings Used
+
+All bindings are used by this module or the modules it delegates to. See the Complete Binding Inventory table above for details.
+
+## Configuration and Limits
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| Worker name | `knowledge-server` | `wrangler.jsonc` |
+| Main entry | `src/index.ts` | `wrangler.jsonc` |
+| Compatibility date | `2025-03-10` | `wrangler.jsonc` |
+| Compatibility flags | `nodejs_compat` | `wrangler.jsonc` |
+| Dev port | 8788 | `wrangler.jsonc` |
+| Branch filter | `refs/heads/main` | `index.ts` |
+
+### Wrangler Resource Configuration
+
+| Resource | Name / ID | Config |
+|----------|-----------|--------|
+| KV: RERANK_CACHE | `bcfbd064dc2b451dbd05a85410b33196` | |
+| KV: SYNC_STATE | `6b98b7a4d10746cf90cbfcdc559597ee` | |
+| Workflow: SYNC_WORKFLOW | `knowledge-sync-workflow` (class: `KnowledgeSyncWorkflow`) | |
+| Vectorize: VECTORIZE | `superbenefit-knowledge-idx` | `remote: true` |
+| R2: KNOWLEDGE | `superbenefit-knowledge` | `remote: true` |
+| Queue consumer | `superbenefit-knowledge-sync` | `max_batch_size: 10, max_batch_timeout: 30` |
+| AI binding | `AI` | |
+| Observability | enabled | |
+
+## Error Handling
+
+| Failure | Response |
+|---------|----------|
+| Invalid webhook signature | 403 `Invalid signature` |
+| Non-main branch push | 200 `{ status: 'ignored', reason: 'not main branch' }` |
+| No markdown changes | 200 `{ status: 'ignored', reason: 'no markdown files changed' }` |
+| Workflow creation fails | Exception propagates (500) |
+| Unmatched route | Hono's default 404 handler |
+
+## Extension Points
+
+**Adding a new top-level route:**
+1. For routes that need Hono middleware (CORS, validation): add to the Hono app or mount a sub-application
+2. For routes that need custom handling (like MCP): add a pathname check in the `fetch` handler before the Hono fallthrough
+
+**Phase 2 — adding authentication middleware:**
+1. Add JWT verification before the MCP and/or API dispatches
+2. Pass the verified identity through to `resolveAuthContext()` (which will need a request parameter in Phase 2)
+
+**Adding a new queue consumer:**
+1. Add a new consumer function
+2. Export it alongside `handleVectorizeQueue` or create a dispatcher that routes by queue name
+
+## Cross-References
+
+- [api.md](api.md) — REST API mounted at `/api/v1`
+- [mcp.md](mcp.md) — MCP server at `/mcp`
+- [sync.md](sync.md) — `KnowledgeSyncWorkflow`, `verifyWebhookSignature()`, `isExcluded()`
+- [consumers.md](consumers.md) — `handleVectorizeQueue()` wired to the `queue` export
+- [types.md](types.md) — `GitHubPushEvent`, `Env` interface
+- `CLAUDE.md` — Router integration pattern
+- `docs/spec.md` sections 1, 5.1, 8, 9 — Architecture, webhook handling, REST API, worker configuration

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -1,0 +1,296 @@
+# MCP
+
+> Implements the Model Context Protocol server with 10 tools, 4 resources, and 3 prompts for AI-assisted knowledge base access.
+
+**Source:** `src/mcp/`
+**Files:** 5 (`index.ts`, `server.ts`, `tools.ts`, `resources.ts`, `prompts.ts`)
+**Spec reference:** `docs/spec.md` sections 7.3-7.5
+**Depends on:** `types`, `auth` (`resolveAuthContext`, `checkTierAccess`), `retrieval` (`searchKnowledge`, `getDocument`)
+**Depended on by:** `index` (routes `/mcp` requests to `McpHandler`)
+
+---
+
+## Overview
+
+The MCP module exposes the knowledge base to AI clients via the Model Context Protocol. It provides three categories of primitives: **tools** (callable functions for search, lookup, and content creation), **resources** (read-only context data like system prompts and ontology documentation), and **prompts** (workflow templates for common research tasks).
+
+The server uses a stateless architecture — a new `McpServer` instance is created for each request via `createMcpHandler` from the `agents/mcp` package. No state persists between requests (no Durable Object). This means every tool, resource, and prompt is re-registered on each invocation, but the overhead is negligible compared to the AI model calls.
+
+Every tool follows the porch access control pattern: call `resolveAuthContext()`, call `checkTierAccess()`, return an error if denied, proceed if allowed. In Phase 1, all tools are open tier, but the guard pattern is in place for Phase 3 when some tools will require members access.
+
+## Data Flow Diagram
+
+```mermaid
+graph TD
+    Client["MCP Client<br/>(Claude, etc.)"] -->|SSE/HTTP| Handler["McpHandler.fetch()"]
+    Handler --> Create["createKnowledgeServer(env)"]
+    Create --> Server["McpServer instance"]
+    Server --> Tools["registerTools()"]
+    Server --> Resources["registerResources()"]
+    Server --> Prompts["registerPrompts()"]
+
+    Tools --> Auth["resolveAuthContext()<br/>+ checkTierAccess()"]
+    Auth --> Retrieval["searchKnowledge()<br/>getDocument()"]
+    Auth --> R2["R2 direct access<br/>(listGroups, listReleases)"]
+    Auth --> Write["R2 writes<br/>(saveLink, createDraft)"]
+
+    Resources --> R2
+    Resources --> Static["Static data<br/>(system prompt, ontology)"]
+```
+
+## File-by-File Reference
+
+### `index.ts`
+
+**Purpose:** Barrel file re-exporting all MCP module components.
+
+#### Exports
+
+| Export | Kind | Source |
+|--------|------|--------|
+| `McpHandler` | Object | `./server` |
+| `createKnowledgeServer` | Function | `./server` |
+| `registerTools` | Function | `./tools` |
+| `listGroups` | Function | `./tools` |
+| `listReleases` | Function | `./tools` |
+| `registerResources` | Function | `./resources` |
+| `registerPrompts` | Function | `./prompts` |
+
+---
+
+### `server.ts`
+
+**Purpose:** Creates and configures the stateless MCP handler.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `McpHandler` | Object | `{ fetch(request, env, ctx): Promise<Response> }` | Stateless request handler |
+| `createKnowledgeServer` | Function | `(env: Env) => McpServer` | Factory for configured server instances |
+
+#### Internal Logic
+
+**`createKnowledgeServer()`:**
+1. Creates a new `McpServer` with name `superbenefit-knowledge` and version `1.0.0`
+2. Calls `registerTools(server, env)`, `registerResources(server, env)`, `registerPrompts(server, env)`
+3. Returns the fully configured server
+
+**`McpHandler.fetch()`:**
+1. Creates a new server instance via `createKnowledgeServer(env)` — per-request, no shared state
+2. Wraps it with `createMcpHandler()` from `agents/mcp`, configured with:
+   - `route: '/mcp'` — path prefix for MCP endpoints
+   - CORS: `origin: '*'`, methods: `GET, POST, DELETE, OPTIONS`, headers: `Content-Type, Authorization, Mcp-Session-Id`
+3. Delegates the request to the handler
+
+**Why `Mcp-Session-Id` in CORS headers:** MCP's Streamable HTTP transport uses this header for session management. Without it in `Access-Control-Allow-Headers`, browser-based MCP clients would fail CORS preflight.
+
+#### Dependencies
+- **Internal:** `./tools`, `./resources`, `./prompts`
+- **External:** `@modelcontextprotocol/sdk/server/mcp.js` (McpServer), `agents/mcp` (createMcpHandler)
+
+---
+
+### `tools.ts`
+
+**Purpose:** Registers all 10 MCP tools with the porch access control guard pattern.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `registerTools` | Function | `(server: McpServer, env: Env) => void` | Register all tools on a server instance |
+| `listGroups` | Function | `(env: Env) => Promise<Array<...>>` | List groups from R2 (shared with resources) |
+| `listReleases` | Function | `(env: Env) => Promise<Array<...>>` | List releases from R2 (shared with resources) |
+
+#### Tool Catalog
+
+| Tool | Parameters | Phase 1 Tier | Phase 3 Tier | Description |
+|------|-----------|-------------|-------------|-------------|
+| `search_knowledge` | `query: string`, `filters?: { contentType?, group?, release? }` | open | open | Semantic search across the knowledge base |
+| `define_term` | `term: string` | open | open | Look up a term definition from the lexicon (tags) |
+| `search_lexicon` | `keyword: string` | open | open | Search lexicon entries by keyword |
+| `list_groups` | (none) | open | open | List all groups/cells |
+| `list_releases` | (none) | open | open | List creative releases |
+| `get_document` | `contentType: ContentType`, `id: string` | open | **members** | Get full document by type and ID |
+| `search_with_documents` | `query: string`, `filters?: SearchFilters` | open | **members** | Search with full document content in results |
+| `save_link` | `url: string`, `title: string`, `description?: string` | open | **members** | Save a new link (as draft) |
+| `create_draft` | `contentType: ContentType`, `title: string`, `content: string` | open | **members** | Create a new draft document |
+
+**Note:** 5 tools are permanently open tier. 4 tools will become members-only in Phase 3 (marked with comments `// Phase 1: 'open'; Phase 3: change to 'members'`). The `search_knowledge` tool was not annotated for Phase 3, implying it stays open.
+
+#### Helper Functions (internal to module)
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `getTermDefinition` | `(term, env) => Promise<string \| null>` | Looks up a tag by converting term to lowercase-hyphenated ID |
+| `searchLexicon` | `(keyword, env) => Promise<Array<{ term, description }>>` | Searches with `contentType: 'tag'` filter |
+| `listGroups` | `(env) => Promise<Array<{ id, title, description? }>>` | Lists R2 objects with `content/group/` prefix |
+| `listReleases` | `(env) => Promise<Array<{ id, title, description? }>>` | Scans all R2 content for unique `release` metadata values |
+| `saveLink` | `(params, authorId, env) => Promise<void>` | Creates a link document in R2 with `publish: false, draft: true` |
+| `createDraft` | `(params, authorId, env) => Promise<R2Document>` | Creates a draft document in R2 |
+
+**`listGroups()` performance note:** Iterates all objects under `content/group/` prefix and fetches each one. For large numbers of groups, this does N+1 R2 calls (1 list + N gets). Acceptable for the current scale.
+
+**`listReleases()` performance note:** Scans ALL objects under `content/` and reads each to find unique `release` metadata values. This is an O(N) full scan. A future optimization would store releases as a separate index.
+
+**`saveLink()` and `createDraft()` details:**
+- Both set `publish: false` and `draft: true` — content is not immediately searchable
+- Both use `authContext.identity?.userId || 'anonymous'` for the author
+- Both generate IDs from the title (lowercased, spaces to hyphens)
+- `saveLink()` uses commit SHA `'user-submitted'`; `createDraft()` uses `'user-draft'`
+
+#### Guard Pattern (applied to every tool)
+
+```typescript
+const authContext = await resolveAuthContext(env);
+const access = checkTierAccess('open', authContext);  // or 'members' in Phase 3
+if (!access.allowed) {
+  return {
+    content: [{ type: 'text', text: `Requires ${access.requiredTier} access. Current: ${access.currentTier}.` }],
+    isError: true,
+  };
+}
+```
+
+#### Dependencies
+- **Internal:** `../types` (ContentTypeSchema, SearchFiltersSchema, ContentType, R2Document), `../retrieval` (searchKnowledge, getDocument), `../types/storage` (toR2Key, generateId), `../auth/resolve`, `../auth/check`
+
+---
+
+### `resources.ts`
+
+**Purpose:** Registers 4 MCP resources providing read-only context data.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `registerResources` | Function | `(server: McpServer, env: Env) => void` | Register all resources |
+
+#### Resource Catalog
+
+| Resource | URI | MIME Type | Description |
+|----------|-----|-----------|-------------|
+| `prompts/knowledge-search` | `mcp://superbenefit/prompts/knowledge-search` | `text/plain` | System prompt for knowledge search — instructions for AI clients on how to use the tools |
+| `data/ontology` | `mcp://superbenefit/data/ontology` | `application/json` | Content type hierarchy and metadata schema documentation |
+| `data/groups` | `mcp://superbenefit/data/groups` | `application/json` | List of groups/cells (dynamic, from R2) |
+| `data/releases` | `mcp://superbenefit/data/releases` | `application/json` | List of releases (dynamic, from R2) |
+
+**System prompt content** covers:
+- SuperBenefit DAO context
+- Instructions for using `search_knowledge` and `define_term`
+- Brief descriptions of all content types
+- Guidance on citing sources and distinguishing documented practices from general knowledge
+
+**Ontology schema** includes:
+- Version (`0.11`)
+- Content type list (from `ContentTypeSchema.options`)
+- Hierarchy tree (file → reference/resource/story/data → concrete types)
+- Metadata field documentation (required, optional, indexed)
+
+**URI scheme:** All resources use `mcp://superbenefit/` as the URI prefix. This is a custom MCP URI scheme, not a standard URL.
+
+#### Dependencies
+- **Internal:** `./tools` (listGroups, listReleases), `../types/content` (ContentTypeSchema, RESOURCE_TYPES, STORY_TYPES, REFERENCE_TYPES, DATA_TYPES)
+- **External:** `@modelcontextprotocol/sdk/server/mcp.js`
+
+---
+
+### `prompts.ts`
+
+**Purpose:** Registers 3 MCP prompt templates for common research workflows.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `registerPrompts` | Function | `(server: McpServer, _env: Env) => void` | Register all prompts |
+
+#### Prompt Catalog
+
+| Prompt | Parameters | Description |
+|--------|-----------|-------------|
+| `research-topic` | `topic: string`, `depth?: 'shallow' \| 'deep'` | Research a topic comprehensively; shallow mode gives brief summary, deep mode provides full analysis with gaps |
+| `explain-pattern` | `pattern: string` | Explain a DAO pattern with definition, practice examples, related patterns, and when to use |
+| `compare-practices` | `practice1: string`, `practice2: string` | Compare two governance/coordination approaches on similarities, differences, and complementarity |
+
+All prompts return a single user message instructing the AI to use `search_knowledge` and `define_term` tools. They do not call tools themselves — they provide structured instructions that the AI client follows.
+
+The `_env` parameter is accepted but unused (prompts are static text templates).
+
+#### Dependencies
+- **External:** `@modelcontextprotocol/sdk/server/mcp.js`, `zod`
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `McpServer` | `@modelcontextprotocol/sdk` | Server instance for registering tools/resources/prompts |
+| `ContentType` | `types/content.ts` | Used in tool parameters |
+| `R2Document` | `types/storage.ts` | Returned by get/search tools |
+| `SearchFilters` | `types/api.ts` | Used in search tool filters |
+| `AuthContext` | `types/auth.ts` | Result of `resolveAuthContext()` |
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `AI` | `Ai` | Via `searchKnowledge()` — embedding and reranking |
+| `VECTORIZE` | `VectorizeIndex` | Via `searchKnowledge()` — similarity search |
+| `KNOWLEDGE` | `R2Bucket` | Document fetch, group listing, release listing, link/draft creation |
+| `RERANK_CACHE` | `KVNamespace` | Via `searchKnowledge()` — reranker cache |
+
+## Configuration and Limits
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| Server name | `superbenefit-knowledge` | `server.ts` |
+| Server version | `1.0.0` | `server.ts` |
+| MCP route | `/mcp` | `server.ts` |
+| CORS origin | `*` | `server.ts` |
+| CORS headers | `Content-Type, Authorization, Mcp-Session-Id` | `server.ts` |
+
+## Error Handling
+
+All tools follow the same error pattern:
+
+| Failure | Behavior |
+|---------|----------|
+| Access denied | Returns `{ isError: true, content: "Requires X access." }` |
+| Document not found | Returns `{ isError: true, content: "Document not found" }` |
+| Term not found | Returns `{ content: 'Term "X" not found in lexicon.' }` (not `isError`) |
+| Search/retrieval error | Exception propagates to MCP SDK, which returns an error response |
+
+## Extension Points
+
+**Adding a new MCP tool:**
+1. Add the tool registration in `registerTools()` in `tools.ts`
+2. Follow the guard pattern: `resolveAuthContext()` → `checkTierAccess()` → logic
+3. Choose the appropriate tier (`'open'` for Phase 1, annotate for future phases)
+4. Update the tool count in `server.ts` comment
+
+**Adding a new MCP resource:**
+1. Add the resource registration in `registerResources()` in `resources.ts`
+2. Use the `mcp://superbenefit/` URI prefix
+3. Choose appropriate MIME type (`text/plain` or `application/json`)
+
+**Adding a new MCP prompt:**
+1. Add the prompt registration in `registerPrompts()` in `prompts.ts`
+2. Define parameters with Zod schemas
+3. Return user messages that instruct the AI to use available tools
+
+**Phase 3 — upgrading tool tiers:**
+1. In `tools.ts`, change `checkTierAccess('open', ...)` to `checkTierAccess('members', ...)` for the 4 marked tools
+2. No other changes needed
+
+## Cross-References
+
+- [auth.md](auth.md) — Porch access control guard pattern
+- [retrieval.md](retrieval.md) — `searchKnowledge()` pipeline called by search tools
+- [types.md](types.md) — `ContentType`, `SearchFilters`, `R2Document` schemas
+- [index.md](index.md) — Routing `/mcp` to `McpHandler`
+- `CLAUDE.md` — Guard boilerplate snippet
+- `docs/spec.md` sections 7.3-7.5 — Full MCP primitive specifications

--- a/docs/src/retrieval.md
+++ b/docs/src/retrieval.md
@@ -1,0 +1,270 @@
+# Retrieval
+
+> Implements the three-stage search pipeline: Vectorize similarity search, BGE reranking with caching, and optional R2 document fetch.
+
+**Source:** `src/retrieval/`
+**Files:** 4 (`index.ts`, `search.ts`, `rerank.ts`, `fetch.ts`)
+**Spec reference:** `docs/spec.md` sections 6.1-6.3
+**Depends on:** `types` (`SearchFilters`, `SearchResult`, `RerankResult`, `R2Document`, `VectorizeMetadata`, `VECTORIZE_LIMITS`, `VECTORIZE_NAMESPACE`, `toR2Key`)
+**Depended on by:** `mcp` (tools), `api` (search route)
+
+---
+
+## Overview
+
+The retrieval module implements the core search pipeline that both MCP tools and the REST API use. It is a three-stage process designed to maximize relevance while minimizing latency and cost:
+
+1. **Stage 1 — Vector Search:** Generates a BGE embedding for the query and searches Vectorize with optional metadata filters, returning up to 20 candidates.
+2. **Stage 2 — Reranking:** Passes the candidates through the BGE reranker model in a single batch API call, normalizes scores with sigmoid, filters below 0.5, and caches results in KV for 1 hour.
+3. **Stage 3 — Document Fetch (optional):** Fetches full R2 documents for the final results, only when `includeDocuments` is requested.
+
+The key design insight is that metadata stored in Vectorize (`content`, `description` fields) provides enough context for reranking without R2 round-trips. Full document fetches are deferred to Stage 3 and only happen when explicitly requested.
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    Query["Search Query<br/>+ Filters"] --> S1
+
+    subgraph "Stage 1: Vector Search"
+        S1["generateEmbedding()<br/>@cf/baai/bge-base-en-v1.5"] --> S1b["Vectorize.query()<br/>topK: 20, filters"]
+    end
+
+    S1b --> S2
+
+    subgraph "Stage 2: Rerank"
+        S2["Check KV Cache"] -->|miss| S2b["AI.run()<br/>@cf/baai/bge-reranker-base<br/>batch contexts, top_k: 5"]
+        S2b --> S2c["sigmoid() normalization<br/>filter >= 0.5<br/>sort descending"]
+        S2c --> S2d["Cache in KV<br/>TTL: 1 hour"]
+    end
+
+    S2 -->|hit| Results
+    S2d --> Results
+
+    subgraph "Stage 3: Document Fetch (optional)"
+        Results --> S3["Promise.all()<br/>R2.get() per result"]
+    end
+
+    S3 --> Final["SearchResult[]"]
+    Results -->|no docs| Final
+```
+
+## File-by-File Reference
+
+### `index.ts`
+
+**Purpose:** Orchestrator that wires the three stages together and exports individual stage functions.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `searchKnowledge` | Async function | `(query, filters, options?, env) => Promise<SearchResult[]>` | Main entry point — runs all three stages |
+| `searchWithFilters` | Re-export | From `./search` | Stage 1 |
+| `generateEmbedding` | Re-export | From `./search` | Embedding helper |
+| `rerankResults` | Re-export | From `./rerank` | Stage 2 |
+| `hashQuery` | Re-export | From `./rerank` | Cache key helper |
+| `getDocuments` | Re-export | From `./fetch` | Batch document fetch |
+| `getDocument` | Re-export | From `./fetch` | Single document fetch |
+
+#### Internal Logic
+
+`searchKnowledge()` is the primary API. It:
+1. Calls `searchWithFilters()` for Stage 1
+2. Returns `[]` immediately if no matches
+3. Calls `rerankResults()` for Stage 2
+4. If `options.includeDocuments` is true, calls `getDocuments()` for Stage 3
+5. Maps reranked results to `SearchResult[]`, attaching documents at matching indices
+
+The `options` parameter currently only supports `includeDocuments?: boolean`. When true, each `SearchResult` includes a `document` field with the full `R2Document`.
+
+#### Dependencies
+- **Internal:** `./search`, `./rerank`, `./fetch`, `../types`
+
+---
+
+### `search.ts`
+
+**Purpose:** Stage 1 — embedding generation and Vectorize similarity search with metadata filtering.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `generateEmbedding` | Async function | `(text: string, env: Env) => Promise<number[]>` | Generate 768-dimensional embedding |
+| `searchWithFilters` | Async function | `(query, filters, env) => Promise<VectorizeMatch[]>` | Full Stage 1 pipeline |
+
+#### Internal Logic
+
+**`generateEmbedding()`:**
+- Uses `@cf/baai/bge-base-en-v1.5` via Workers AI
+- Produces a 768-dimensional vector
+- Throws if the AI model returns no data
+
+**`buildVectorFilter()` (internal):**
+- Converts `SearchFilters` to Vectorize's `VectorizeVectorMetadataFilter` format
+- Only includes fields that are actually set (avoids unnecessary filter constraints)
+- Maps each field to `{ $eq: value }` comparisons
+- For `tags`, uses `{ $in: tags }` for any-match semantics
+- Returns `undefined` if no filters are active
+
+**`searchWithFilters()`:**
+1. Generates embedding for the query text
+2. Builds the optional metadata filter
+3. Queries Vectorize with:
+   - `topK: 20` (maximum when returning metadata)
+   - `returnMetadata: 'all'` (needed for reranking context)
+   - `namespace: 'superbenefit'` (multi-tenant isolation)
+   - Optional filter object
+4. Returns the raw `VectorizeMatch[]` array
+
+#### Dependencies
+- **Internal:** `../types` (SearchFilters, VECTORIZE_LIMITS, VECTORIZE_NAMESPACE)
+- **External:** Cloudflare Workers AI (`env.AI`), Cloudflare Vectorize (`env.VECTORIZE`)
+
+---
+
+### `rerank.ts`
+
+**Purpose:** Stage 2 — rerank Vectorize matches using BGE reranker with sigmoid normalization and KV caching.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `rerankResults` | Async function | `(query, matches, env) => Promise<RerankResult[]>` | Rerank and filter matches |
+| `hashQuery` | Function | `(query, ids) => string` | Generate cache key hash |
+
+#### Internal Logic
+
+**`hashQuery()`:**
+- Concatenates query + sorted IDs into a single string
+- Computes a 32-bit hash (djb2 variant) and returns hex representation
+- Used for KV cache keys: `rerank:{hash}`
+
+**`sigmoid()`** (internal):
+- Standard sigmoid function: `1 / (1 + exp(-x))`
+- Normalizes raw reranker logits from (-inf, +inf) to (0, 1)
+- The 0.5 threshold corresponds to a raw logit of 0
+
+**`rerankResults()`:**
+1. Returns `[]` for empty input
+2. Checks KV cache (`RERANK_CACHE`) with key `rerank:{hash}` — returns cached result on hit
+3. Extracts content snippets from Vectorize metadata for each match, falling back to description, then empty string
+4. Makes a single batch call to `@cf/baai/bge-reranker-base` with:
+   - `query`: the original search query
+   - `contexts`: array of `{ text: snippet }` objects
+   - `top_k: 5` (RERANK_TOP_K constant)
+5. Maps reranker output back to original matches using the index-based `r.id`
+6. Applies sigmoid normalization to each score
+7. Filters out results with normalized score < 0.5
+8. Sorts by `rerankScore` descending
+9. Caches the result array in KV with 1-hour TTL (`expirationTtl: 3600`)
+
+**Reranker response format:** The BGE reranker returns `{ response: [{ id: number, score: number }] }` where `id` is the 0-based index into the `contexts` array. This is mapped back to the original `matches` array to recover the Vectorize match.
+
+#### Dependencies
+- **Internal:** `../types` (RerankResult, VectorizeMetadata)
+- **External:** Cloudflare Workers AI (`env.AI`), Cloudflare KV (`env.RERANK_CACHE`)
+
+---
+
+### `fetch.ts`
+
+**Purpose:** Stage 3 — fetch full documents from R2 for final results.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `getDocuments` | Async function | `(results: RerankResult[], env) => Promise<R2Document[]>` | Batch fetch documents |
+| `getDocument` | Async function | `(contentType, id, env) => Promise<R2Document \| null>` | Single document fetch |
+
+#### Internal Logic
+
+**`getDocuments()`:**
+- Fetches all documents in parallel via `Promise.all()`
+- Uses `result.metadata.path` (the R2 key stored in Vectorize metadata) for each lookup
+- Skips results with no path
+- Parses R2 objects as JSON to `R2Document`
+- Filters out null results (missing R2 objects)
+
+**`getDocument()`:**
+- Constructs the R2 key using `toR2Key(contentType, id)`
+- Returns `null` if the R2 object doesn't exist
+- Used by the `get_document` MCP tool and the REST API's `GET /entries/:type/:id`
+
+#### Dependencies
+- **Internal:** `../types` (ContentType, R2Document, RerankResult, toR2Key)
+- **External:** Cloudflare R2 (`env.KNOWLEDGE`)
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `SearchFilters` | `types/api.ts` | Filter input: `contentType`, `group`, `release`, `status`, `tags` |
+| `SearchResult` | `types/api.ts` | Final output: `id`, `contentType`, `title`, `score`, `rerankScore`, optional `document` |
+| `RerankResult` | `types/api.ts` | Internal: `id`, `score` (vector), `rerankScore` (reranker), `metadata` |
+| `VectorizeMetadata` | `types/storage.ts` | Metadata on vectors, includes `content` snippet for reranking |
+| `VectorizeMatch` | Cloudflare types | Vectorize query result with `id`, `score`, `metadata` |
+
+See [types.md](types.md) for full definitions.
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `AI` | `Ai` | BGE embedding generation (Stage 1), BGE reranking (Stage 2) |
+| `VECTORIZE` | `VectorizeIndex` | Similarity search (Stage 1) |
+| `RERANK_CACHE` | `KVNamespace` | Caching reranker results (Stage 2, 1-hour TTL) |
+| `KNOWLEDGE` | `R2Bucket` | Document fetch (Stage 3) |
+
+## Configuration and Limits
+
+| Constant | Value | Location | Source |
+|----------|-------|----------|--------|
+| `topK` (vector search) | 20 | `search.ts` | `VECTORIZE_LIMITS.TOP_K_WITH_METADATA` |
+| `RERANK_TOP_K` | 5 | `rerank.ts` | Spec section 6.3 |
+| Sigmoid threshold | 0.5 | `rerank.ts` | Raw logit of 0 = neutral relevance |
+| Cache TTL | 3600s (1 hour) | `rerank.ts` | Application config |
+| Embedding model | `@cf/baai/bge-base-en-v1.5` | `search.ts` | 768-dimensional, English |
+| Reranker model | `@cf/baai/bge-reranker-base` | `rerank.ts` | Cross-encoder |
+| Vectorize namespace | `'superbenefit'` | `search.ts` | `VECTORIZE_NAMESPACE` constant |
+
+## Error Handling
+
+| Failure | Behavior |
+|---------|----------|
+| Embedding returns no data | Throws `Error('Embedding generation returned no data')` |
+| Vectorize query fails | Exception propagates to caller |
+| Reranker returns no `response` | Returns empty `RerankResult[]` (no results) |
+| KV cache read fails | Exception propagates (no fallback) |
+| R2 object missing | Filtered out (returns null, excluded from results) |
+
+Errors are not caught within the retrieval module — they propagate to the calling MCP tool or API route, which handles them with appropriate error responses.
+
+## Extension Points
+
+**Adding a new search filter:**
+1. Add the field to `SearchFiltersSchema` in `types/api.ts`
+2. Add a corresponding filter clause in `buildVectorFilter()` in `search.ts`
+3. Ensure the Vectorize metadata index exists for the field
+
+**Adjusting reranker behavior:**
+- Change `RERANK_TOP_K` to return more/fewer results from the reranker
+- Change the sigmoid threshold (currently 0.5) to be more/less permissive
+- Change the KV TTL to cache longer or shorter
+
+**Replacing the embedding or reranker model:**
+- Update the model ID in `generateEmbedding()` or `rerankResults()`
+- If the embedding dimensions change, recreate the Vectorize index
+
+## Cross-References
+
+- [types.md](types.md) — `SearchResult`, `RerankResult`, `VectorizeMetadata` schemas
+- [consumers.md](consumers.md) — How documents get indexed into Vectorize (the write side of this read pipeline)
+- [mcp.md](mcp.md) — `search_knowledge` and `search_with_documents` tools that call `searchKnowledge()`
+- [api.md](api.md) — `GET /search` route that calls `searchKnowledge()`
+- `docs/spec.md` sections 6.1-6.3 — Full search pipeline specification

--- a/docs/src/sync.md
+++ b/docs/src/sync.md
@@ -1,0 +1,254 @@
+# Sync
+
+> Syncs markdown content from GitHub to R2 via a Cloudflare Workflow, with webhook verification, file fetching, and frontmatter parsing.
+
+**Source:** `src/sync/`
+**Files:** 3 (`workflow.ts`, `github.ts`, `parser.ts`)
+**Spec reference:** `docs/spec.md` section 5
+**Depends on:** `types` (`SyncParams`, `ContentType`, `R2Document`, `inferContentType`, `generateId`, `toR2Key`, `ContentTypeSchema`, `FileSchema`, `ParsedMarkdown`)
+**Depended on by:** `index` (webhook handler triggers workflow, re-exports `KnowledgeSyncWorkflow`)
+
+---
+
+## Overview
+
+The sync module handles the pipeline from GitHub push events to R2 document storage. When a contributor pushes markdown files to the knowledge repository on GitHub, a webhook fires, the entry point validates and triggers a Cloudflare Workflow, and the workflow fetches, parses, and stores each file.
+
+The sync pipeline is selective — only published, non-draft markdown files are stored in R2. Files that fail the publish gate but were previously stored are cleaned up (deleted from R2). This means "unpublishing" a document by changing `publish: false` in frontmatter will remove it from the knowledge base.
+
+The workflow uses Cloudflare's built-in retry mechanism with exponential backoff for transient failures (rate limits, server errors), while permanent failures like 404s are marked non-retryable.
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    GH["GitHub Push"] -->|webhook POST| WH["handleWebhook()<br/>in src/index.ts"]
+    WH -->|verify signature| Sig["verifyWebhookSignature()"]
+    WH -->|filter branch| Branch["refs/heads/main only"]
+    WH -->|collect files| Dedup["Deduplicate .md files<br/>+ isExcluded() filter"]
+    Dedup -->|trigger| WF["KnowledgeSyncWorkflow"]
+
+    subgraph "Workflow (per file)"
+        WF --> Fetch["fetchFileContent()<br/>GitHub Contents API"]
+        Fetch --> Parse["parseMarkdown()<br/>YAML frontmatter"]
+        Parse --> Gate{"shouldSync()?<br/>publish && !draft"}
+        Gate -->|yes| Resolve["resolveContentType()<br/>frontmatter → path fallback"]
+        Resolve --> Store["R2.put()<br/>content/{type}/{id}.json"]
+        Gate -->|no| Cleanup["Check if previously synced<br/>→ R2.delete() if exists"]
+    end
+
+    WF -->|deleted files| Del["R2.delete()<br/>inferContentType + generateId"]
+
+    Store -->|R2 event| Queue["Queue → Vectorize<br/>(see consumers.md)"]
+```
+
+## File-by-File Reference
+
+### `workflow.ts`
+
+**Purpose:** Cloudflare Workflow that processes changed and deleted markdown files from GitHub.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `KnowledgeSyncWorkflow` | Class | `extends WorkflowEntrypoint<Env, SyncParams>` | Workflow class discovered by wrangler |
+
+#### Internal Logic
+
+The workflow receives a `SyncParams` payload containing `changedFiles`, `deletedFiles`, and `commitSha`.
+
+**Changed files processing** — each file gets its own workflow step (`sync-{filePath}`):
+
+1. **Retry policy:** 5 retries, 30-second initial delay, exponential backoff, 2-minute timeout per step
+2. **Fetch:** Calls `fetchFileContent()` with the file path, commit SHA, repo, and token from `this.env`
+3. **404 handling:** Wraps fetch in try/catch — if the GitHub API returns 404, throws `NonRetryableError` (workflow won't retry). Other HTTP errors (429, 5xx) are retried.
+4. **Parse:** Calls `parseMarkdown()` to extract frontmatter and body
+5. **Publish gate:** Calls `shouldSync()` — if the file is not published or is a draft:
+   - Resolves the content type and ID
+   - Checks if a previously-synced version exists in R2 via `R2.head()`
+   - If it exists, deletes it (unpublish behavior)
+   - Returns early (skip sync)
+6. **Store:** Builds an `R2Document` and puts it in R2 at `content/{type}/{id}.json`
+
+**Deleted files processing** — simpler steps (`delete-{filePath}`):
+1. Infers content type from file path using `inferContentType()`
+2. Generates ID from file path using `generateId()`
+3. Deletes the R2 object at the computed key
+
+**`R2Document` construction:**
+```typescript
+{
+  id: generateId(filePath),           // "cell-governance"
+  contentType: resolveContentType(),   // "pattern"
+  path: filePath,                      // "artifacts/patterns/cell-governance.md"
+  metadata: parsed.frontmatter,        // { title, description, ... }
+  content: parsed.body,                // Markdown after frontmatter
+  syncedAt: new Date().toISOString(), // When synced
+  commitSha,                           // Git SHA
+}
+```
+
+#### Dependencies
+- **Internal:** `../types/sync` (SyncParams), `../types/content` (inferContentType), `../types/storage` (generateId, toR2Key, R2Document), `./parser`, `./github`
+- **External:** `cloudflare:workers` (WorkflowEntrypoint, WorkflowStep, WorkflowEvent), `cloudflare:workflows` (NonRetryableError)
+
+---
+
+### `github.ts`
+
+**Purpose:** GitHub API helpers — webhook signature verification, file content fetching, and path exclusion rules.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `isExcluded` | Function | `(filePath: string) => boolean` | Check if a file should be excluded from sync |
+| `verifyWebhookSignature` | Async function | `(body, signatureHeader, secret) => Promise<boolean>` | Verify GitHub HMAC-SHA256 signature |
+| `fetchFileContent` | Async function | `(filePath, commitSha, repo, token) => Promise<string>` | Fetch raw file content from GitHub |
+
+#### Internal Logic
+
+**`isExcluded()`:**
+
+Checks file paths against two exclusion lists:
+- **Prefix exclusions:** `tools/`, `templates/`, `.obsidian/`, `.github/`
+- **Filename exclusions:** `README.md`, `LICENSE.md`, `CONTRIBUTING.md`
+
+**`verifyWebhookSignature()`:**
+
+Implements HMAC-SHA256 signature verification using Web Crypto API:
+1. Parses the `x-hub-signature-256` header, expecting format `sha256=<hex>`
+2. Imports the shared secret as an HMAC key
+3. Signs the request body with the key
+4. Converts the signature to hex
+5. **Constant-time comparison:** Compares each character with XOR, accumulating mismatches to prevent timing attacks
+
+**`fetchFileContent()`:**
+
+Fetches file content from the GitHub Contents API:
+1. URL-encodes each path segment individually (preserving literal slashes)
+2. Requests `https://api.github.com/repos/{repo}/contents/{path}?ref={commitSha}`
+3. Uses Bearer token authentication and the `application/vnd.github.v3+json` Accept header
+4. Sets `User-Agent: superbenefit-knowledge-server`
+5. On non-2xx responses: creates an Error with `status` property attached for the workflow to distinguish retryable vs. non-retryable failures
+6. For base64-encoded responses: strips whitespace (GitHub line-wraps base64) then decodes with `atob()`
+7. Falls back to raw `data.content` for non-base64 encoding
+
+#### Dependencies
+- **External:** Web Crypto API (`crypto.subtle`), Fetch API
+
+---
+
+### `parser.ts`
+
+**Purpose:** Markdown parsing — frontmatter extraction, validation, content type resolution, and publish gate.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `parseMarkdown` | Function | `(raw: string) => ParsedMarkdown` | Parse YAML frontmatter and body from markdown |
+| `validateFrontmatter` | Function | `(frontmatter) => Record \| null` | Validate against FileSchema |
+| `shouldSync` | Function | `(frontmatter) => boolean` | Check publish and draft flags |
+| `resolveContentType` | Function | `(frontmatter, filePath) => ContentType` | Determine content type from frontmatter or path |
+
+#### Internal Logic
+
+**`parseMarkdown()`:**
+- Uses regex `FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/` to split frontmatter from body
+- Parses YAML using the `yaml` package's `parse()` function
+- Returns `{ frontmatter: {}, body: raw.trim() }` if no frontmatter match or YAML parse failure
+- Validates parsed YAML is a plain object (not array, null, or non-object)
+
+**`validateFrontmatter()`:**
+- Validates frontmatter against `FileSchema` using `safeParse()`
+- Returns parsed data on success, `null` on failure
+- Used for validation but not currently called in the sync pipeline (the workflow stores raw frontmatter)
+
+**`shouldSync()`:**
+- Returns `true` only if `publish === true` AND `draft !== true`
+- This is the gate that prevents unpublished or draft content from entering the knowledge base
+
+**`resolveContentType()`:**
+- First checks `frontmatter.type` — if it's a string that passes `ContentTypeSchema.safeParse()`, uses it
+- Falls back to `inferContentType(filePath)` which uses `PATH_TYPE_MAP`
+- This means frontmatter `type` takes priority over directory-based inference
+
+#### Dependencies
+- **Internal:** `../types/content` (ContentTypeSchema, FileSchema, inferContentType), `../types/sync` (ParsedMarkdown)
+- **External:** `yaml` (YAML parser)
+
+---
+
+## Key Types
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `SyncParams` | `types/sync.ts` | `{ changedFiles, deletedFiles, commitSha }` |
+| `R2Document` | `types/storage.ts` | Document stored in R2 |
+| `ParsedMarkdown` | `types/sync.ts` | `{ frontmatter, body }` |
+| `GitHubPushEvent` | `types/sync.ts` | Subset of GitHub push webhook payload |
+| `ContentType` | `types/content.ts` | 20-type union |
+
+See [types.md](types.md) for full definitions.
+
+## Cloudflare Bindings Used
+
+| Binding | Type | Usage |
+|---------|------|-------|
+| `KNOWLEDGE` | `R2Bucket` | Store and delete documents |
+| `SYNC_WORKFLOW` | `Workflow` | Trigger workflow from webhook handler |
+| `GITHUB_TOKEN` | `string` (secret) | GitHub API authentication |
+| `GITHUB_WEBHOOK_SECRET` | `string` (secret) | Webhook HMAC verification |
+| `GITHUB_REPO` | `string` (secret) | Repository in `owner/repo` format |
+
+## Configuration and Limits
+
+| Setting | Value | Source |
+|---------|-------|--------|
+| Workflow name | `knowledge-sync-workflow` | `wrangler.jsonc` |
+| Workflow binding | `SYNC_WORKFLOW` | `wrangler.jsonc` |
+| Class name | `KnowledgeSyncWorkflow` | `wrangler.jsonc` |
+| Step retries | 5 | `workflow.ts` |
+| Initial retry delay | 30 seconds | `workflow.ts` |
+| Retry backoff | exponential | `workflow.ts` |
+| Step timeout | 2 minutes | `workflow.ts` |
+| Excluded prefixes | `tools/`, `templates/`, `.obsidian/`, `.github/` | `github.ts` |
+| Excluded files | `README.md`, `LICENSE.md`, `CONTRIBUTING.md` | `github.ts` |
+| Branch filter | `refs/heads/main` | `src/index.ts` (webhook handler) |
+
+## Error Handling
+
+| Failure | Behavior |
+|---------|----------|
+| Invalid webhook signature | Returns 403 (in `handleWebhook()`, `src/index.ts`) |
+| Non-main branch push | Returns `{ status: 'ignored' }` (in `handleWebhook()`) |
+| GitHub API 404 | `NonRetryableError` — step fails permanently |
+| GitHub API 429 / 5xx | Error propagates — step retries with backoff |
+| YAML parse failure | Returns `{ frontmatter: {}, body: raw }` — no crash |
+| Invalid YAML (array, null) | Treated as `{}` — parse continues safely |
+| Unpublished file | Silently cleaned up from R2 if previously synced |
+
+## Extension Points
+
+**Adding new exclusion rules:**
+1. Add prefixes to `EXCLUDED_PREFIXES` or filenames to `EXCLUDED_FILES` in `github.ts`
+
+**Adding a new sync source (not GitHub):**
+1. Create a new file in `src/sync/` for the source-specific fetching
+2. Create a new webhook handler or trigger mechanism
+3. Reuse `parseMarkdown()`, `shouldSync()`, and `resolveContentType()` from `parser.ts`
+4. Build `R2Document` objects in the same shape
+
+**Processing non-markdown files:**
+1. Add a new parser alongside `parseMarkdown()` in `parser.ts`
+2. Add file extension filtering in the webhook handler
+3. Ensure the content type mapping covers the new file type
+
+## Cross-References
+
+- [types.md](types.md) — `SyncParams`, `R2Document`, `ParsedMarkdown`, `ContentType` definitions
+- [consumers.md](consumers.md) — Queue consumer that processes R2 events after sync writes
+- [index.md](index.md) — `handleWebhook()` function and `KnowledgeSyncWorkflow` re-export
+- `docs/spec.md` section 5 — Full sync pipeline specification

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -1,0 +1,364 @@
+# Types
+
+> Defines the entire type system: 20-type content ontology, auth model, API shapes, storage schemas, and sync payloads.
+
+**Source:** `src/types/`
+**Files:** 6 (`index.ts`, `content.ts`, `auth.ts`, `api.ts`, `storage.ts`, `sync.ts`)
+**Spec reference:** `docs/spec.md` sections 2, 3, 4, 5, 6, 8
+**Depends on:** none (leaf module)
+**Depended on by:** `auth`, `retrieval`, `consumers`, `sync`, `mcp`, `api`, `index`
+
+---
+
+## Overview
+
+The types directory is the foundation of the entire codebase. Every other module imports from it, and nothing imports into it. It defines Zod schemas that serve triple duty: runtime validation, TypeScript type inference, and OpenAPI documentation generation (via `@hono/zod-openapi`).
+
+The type system models SuperBenefit's knowledge ontology — a 20-type hierarchy of content ranging from governance patterns and coordination protocols to people, groups, and events. This ontology is reflected in storage (R2 key paths, Vectorize metadata), search (filter schemas), and API responses.
+
+All schemas use `@hono/zod-openapi`'s `.openapi()` extension to attach OpenAPI metadata, making them available in the auto-generated `/api/v1/openapi.json` spec.
+
+## Data Flow Diagram
+
+```mermaid
+graph LR
+    subgraph "Type System"
+        content["content.ts<br/>20 content types"]
+        auth["auth.ts<br/>Access tiers"]
+        storage["storage.ts<br/>R2 + Vectorize shapes"]
+        api["api.ts<br/>API request/response"]
+        sync["sync.ts<br/>Sync payloads"]
+        idx["index.ts<br/>Re-exports"]
+    end
+
+    content --> storage
+    content --> api
+    storage --> api
+    auth --> idx
+    content --> idx
+    api --> idx
+    storage --> idx
+    sync --> idx
+
+    idx --> mcp["src/mcp/"]
+    idx --> retrieval["src/retrieval/"]
+    idx --> consumers["src/consumers/"]
+    idx --> syncmod["src/sync/"]
+    idx --> apimod["src/api/"]
+```
+
+## File-by-File Reference
+
+### `index.ts`
+
+**Purpose:** Barrel file that re-exports all types, schemas, and helpers from the other five files.
+
+#### Exports
+
+All exports are re-exports. Organized into sections by spec reference:
+
+| Section | Schemas | Types | Helpers |
+|---------|---------|-------|---------|
+| Content (spec 3) | `ContentTypeSchema`, `FileSchema`, `ResourceSchema`, `StorySchema`, `DataSchema`, `ReferenceSchema`, `ContentSchema`, + 14 concrete schemas | `ContentType`, `Content`, `FileFrontmatter`, + 14 concrete frontmatter types | `inferContentType`, `RESOURCE_TYPES`, `STORY_TYPES`, `REFERENCE_TYPES`, `DATA_TYPES`, `PATH_TYPE_MAP` |
+| Auth (spec 2) | `AccessTierSchema`, `IdentitySchema`, `AuthContextSchema` | `AccessTier`, `Identity`, `AuthContext` | `TIER_LEVEL` |
+| API (spec 6, 8) | `SearchFiltersSchema`, `ListParamsSchema`, `SearchParamsSchema`, `SearchResultSchema`, `RerankResultSchema`, `ErrorResponseSchema`, `EntryResponseSchema`, `EntryListResponseSchema`, `SearchResponseSchema` | `SearchFilters`, `ListParams`, `SearchParams`, `SearchResult`, `RerankResult`, `ErrorResponse` | |
+| Storage (spec 4) | `R2DocumentSchema`, `VectorizeMetadataSchema` | `R2Document`, `VectorizeMetadata` | `truncateForMetadata`, `generateId`, `toR2Key`, `extractIdFromKey`, `extractContentTypeFromKey`, `VECTORIZE_LIMITS`, `VECTORIZE_NAMESPACE` |
+| Sync (spec 5) | `SyncParamsSchema` | `SyncParams`, `R2EventNotification`, `GitHubPushEvent`, `ParsedMarkdown` | |
+
+#### Dependencies
+- **Internal:** `./content`, `./auth`, `./api`, `./storage`, `./sync`
+- **External:** none
+
+---
+
+### `content.ts`
+
+**Purpose:** Defines the 20-type content ontology as a Zod schema hierarchy with discriminated union.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `ContentTypeSchema` | Zod enum | All 20 content type literals |
+| `ContentType` | Type | Inferred union type |
+| `RESOURCE_TYPES` | Constant | `['pattern', 'practice', 'primitive', 'protocol', 'playbook', 'question']` |
+| `STORY_TYPES` | Constant | `['study', 'article']` |
+| `REFERENCE_TYPES` | Constant | `['index', 'link', 'tag']` |
+| `DATA_TYPES` | Constant | `['person', 'group', 'project', 'place', 'gathering']` |
+| `PATH_TYPE_MAP` | Record | Maps 17 path prefixes to content types |
+| `inferContentType()` | Function | `(path: string) => ContentType` — falls back to `'file'` |
+| `FileSchema` | Zod object | Base schema with `title`, `date`, `publish`, `draft`, etc. |
+| `ResourceSchema` | Zod object | Extends `FileSchema` with `release`, `hasPart`, `isPartOf` |
+| `StorySchema` | Zod object | Extends `FileSchema` with `release` |
+| `DataSchema` | Zod object | Alias for `FileSchema` |
+| `ReferenceSchema` | Zod object | Alias for `FileSchema` |
+| `LinkSchema` | Zod object | Extends `ReferenceSchema` with `url` (required) |
+| `TagSchema` | Zod object | Extends `ReferenceSchema` with `aliases`, `relatedTerms`, `category` |
+| `PatternSchema` | Zod object | Extends `ResourceSchema` with `context`, `problem`, `solution`, `relatedPatterns` |
+| `PracticeSchema` | Zod object | Extends `ResourceSchema` with `patterns`, `practitioners` |
+| `PrimitiveSchema` | Zod object | Extends `ResourceSchema` with `category` |
+| `ProtocolSchema` | Zod object | Extends `ResourceSchema` with `steps` |
+| `PlaybookSchema` | Zod object | Alias for `ResourceSchema` |
+| `QuestionSchema` | Zod object | Extends `ResourceSchema` with `status` (`open`/`exploring`/`resolved`), `related`, `proposedBy` |
+| `StudySchema` | Zod object | Alias for `StorySchema` |
+| `ArticleSchema` | Zod object | Extends `StorySchema` with `url`, `curator`, `harvester` |
+| `PersonSchema` | Zod object | Extends `DataSchema` with `aliases`, `roles`, `groups`, `homepage`, `email`, `image` |
+| `GroupSchema` | Zod object | Extends `DataSchema` with `aliases`, `members`, `homepage`, `logo` |
+| `ProjectSchema` | Zod object | Extends `DataSchema` with `status` (`active`/`completed`/`paused`/`archived`), `lead`, `homepage` |
+| `PlaceSchema` | Zod object | Extends `DataSchema` with `coordinates` (`{lat, lng}`), `region` |
+| `GatheringSchema` | Zod object | Extends `DataSchema` with `eventDate`, `location`, `attendees`, `homepage` |
+| `ContentSchema` | Discriminated union | Union of 16 concrete types, discriminated on `type` field |
+
+#### Internal Logic
+
+**Schema inheritance tree:**
+
+```mermaid
+graph TD
+    FileSchema --> ReferenceSchema
+    FileSchema --> ResourceSchema["ResourceSchema<br/>(+release, hasPart, isPartOf)"]
+    FileSchema --> StorySchema["StorySchema<br/>(+release)"]
+    FileSchema --> DataSchema
+
+    ReferenceSchema --> LinkSchema["LinkSchema (+url)"]
+    ReferenceSchema --> TagSchema["TagSchema (+aliases, relatedTerms)"]
+
+    ResourceSchema --> PatternSchema["PatternSchema (+context, problem, solution)"]
+    ResourceSchema --> PracticeSchema["PracticeSchema (+patterns, practitioners)"]
+    ResourceSchema --> PrimitiveSchema["PrimitiveSchema (+category)"]
+    ResourceSchema --> ProtocolSchema["ProtocolSchema (+steps)"]
+    ResourceSchema --> PlaybookSchema
+    ResourceSchema --> QuestionSchema["QuestionSchema (+status, related)"]
+
+    StorySchema --> StudySchema
+    StorySchema --> ArticleSchema["ArticleSchema (+url, curator)"]
+
+    DataSchema --> PersonSchema["PersonSchema (+roles, groups, email)"]
+    DataSchema --> GroupSchema["GroupSchema (+members, homepage)"]
+    DataSchema --> ProjectSchema["ProjectSchema (+status, lead)"]
+    DataSchema --> PlaceSchema["PlaceSchema (+coordinates)"]
+    DataSchema --> GatheringSchema["GatheringSchema (+eventDate, location)"]
+```
+
+**`FileSchema` base fields** (all concrete types inherit these):
+- `type` — optional ContentType (set explicitly in discriminated union)
+- `title` — required, min 1 char
+- `description` — optional string
+- `date` — required, coerced to Date
+- `publish` — boolean, defaults to `false`
+- `draft` — boolean, defaults to `false`
+- `permalink` — optional string
+- `author` — optional string array
+- `group` — optional string
+
+**`PATH_TYPE_MAP`** maps repository directory prefixes to content types. Used by `inferContentType()` when frontmatter doesn't specify a `type` field. The mapping covers:
+- `artifacts/patterns` → `pattern`, `artifacts/practices` → `practice`, etc.
+- `data/people` → `person`, `data/groups` → `group`, etc.
+- `links` → `link`, `tags` → `tag`
+- `notes` / `drafts` → `file` (catch-all)
+
+**`ContentSchema` discriminated union** includes 16 of the 20 types (excludes parent types `reference`, `resource`, `story`, `data` and the root `index` type as they are not standalone document types in the union).
+
+#### Dependencies
+- **External:** `@hono/zod-openapi` (Zod with OpenAPI extensions)
+
+---
+
+### `auth.ts`
+
+**Purpose:** Defines the three-tier access control model for the porch framework.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `AccessTier` | Type | `'open' \| 'public' \| 'members'` |
+| `AccessTierSchema` | Zod enum | Schema version of AccessTier |
+| `TIER_LEVEL` | Record | Numeric ordering: `{ open: 0, public: 1, members: 2 }` |
+| `Identity` | Interface | `{ userId, name, email, provider }` |
+| `IdentitySchema` | Zod object | Schema for Identity |
+| `AuthContext` | Interface | `{ identity: Identity \| null, tier: AccessTier }` |
+| `AuthContextSchema` | Zod object | Schema for AuthContext |
+
+#### Internal Logic
+
+The three tiers represent increasing access levels:
+- **open (0):** Anonymous, no auth required — Phase 1 default
+- **public (1):** Authenticated via Cloudflare Access for SaaS — Phase 2
+- **members (2):** Token-gated via Hats Protocol on Optimism — Phase 3
+
+`TIER_LEVEL` provides numeric comparison: a request with tier level >= required tier level passes the access check. This is used by `checkTierAccess()` in `src/auth/check.ts`.
+
+#### Dependencies
+- **External:** `@hono/zod-openapi`
+
+---
+
+### `api.ts`
+
+**Purpose:** Defines REST API request/response shapes for search, listing, and error handling.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `SearchFiltersSchema` | Zod object | Shared filter fields: `contentType`, `group`, `release`, `status`, `tags` |
+| `SearchFilters` | Type | Inferred type |
+| `ListParamsSchema` | Zod object | Pagination: `contentType`, `group`, `release`, `limit` (1-100, default 20), `offset` (min 0) |
+| `ListParams` | Type | Inferred type |
+| `SearchParamsSchema` | Zod object | Search: `q` (required), `contentType`, `group`, `release`, `limit` (1-20, default 5) |
+| `SearchParams` | Type | Inferred type |
+| `SearchResultSchema` | Zod object | Result: `id`, `contentType`, `title`, `description?`, `score`, `rerankScore?`, `document?` |
+| `SearchResult` | Type | Inferred type |
+| `RerankResultSchema` | Zod object | Reranked result: `id`, `score`, `rerankScore`, `metadata` (VectorizeMetadata) |
+| `RerankResult` | Type | Inferred type |
+| `ErrorResponseSchema` | Zod object | `{ error: { code, message } }` |
+| `ErrorResponse` | Type | Inferred type |
+| `EntryResponseSchema` | Zod object | `{ data: R2Document }` |
+| `EntryListResponseSchema` | Zod object | `{ data: R2Document[], total, offset, limit }` |
+| `SearchResponseSchema` | Zod object | `{ results: SearchResult[] }` |
+
+#### Internal Logic
+
+The `SearchFiltersSchema` is shared between REST API and MCP tools — both use the same filter vocabulary. The `tags` field accepts an array of strings, which maps to the comma-separated tags stored in Vectorize metadata via `$in` filter semantics.
+
+#### Dependencies
+- **Internal:** `./content` (ContentTypeSchema), `./storage` (R2DocumentSchema, VectorizeMetadataSchema)
+- **External:** `@hono/zod-openapi`
+
+---
+
+### `storage.ts`
+
+**Purpose:** Defines R2 document shape, Vectorize metadata schema, and helpers for ID generation and R2 key construction.
+
+#### Exports
+
+| Export | Kind | Signature | Description |
+|--------|------|-----------|-------------|
+| `VECTORIZE_LIMITS` | Constant | `{ METADATA_MAX_BYTES: 10240, VECTOR_ID_MAX_BYTES: 64, STRING_INDEX_MAX_BYTES: 64, TOP_K_WITH_METADATA: 20, TOP_K_WITHOUT_METADATA: 100, MAX_METADATA_INDEXES: 10 }` | Hard limits from Cloudflare Vectorize |
+| `VECTORIZE_NAMESPACE` | Constant | `'superbenefit'` | Namespace for multi-tenant isolation |
+| `R2DocumentSchema` | Zod object | | Document stored in R2 as JSON |
+| `R2Document` | Type | | Inferred type |
+| `VectorizeMetadataSchema` | Zod object | | Metadata attached to each vector |
+| `VectorizeMetadata` | Type | | Inferred type |
+| `truncateForMetadata` | Function | `(content: string) => string` | Truncate to 8000 chars at word boundary |
+| `generateId` | Function | `(path: string) => string` | Extract filename stem, enforce 64-byte limit |
+| `toR2Key` | Function | `(contentType, id) => string` | Build R2 key: `content/{type}/{id}.json` |
+| `extractIdFromKey` | Function | `(key: string) => string` | Reverse of `toR2Key` for ID |
+| `extractContentTypeFromKey` | Function | `(key: string) => ContentType` | Reverse of `toR2Key` for type |
+
+#### Internal Logic
+
+**`R2Document` shape:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique ID derived from filename (max 64 bytes) |
+| `contentType` | ContentType | One of the 20 content types |
+| `path` | string | Original GitHub repository path |
+| `metadata` | `Record<string, unknown>` | Parsed YAML frontmatter |
+| `content` | string | Markdown body (after frontmatter) |
+| `syncedAt` | string (ISO datetime) | When the document was last synced |
+| `commitSha` | string | Git commit SHA that triggered the sync |
+
+**`VectorizeMetadata` shape** (must fit within 10 KiB per vector):
+
+| Field | Type | Indexed | Description |
+|-------|------|---------|-------------|
+| `contentType` | string | Yes | Content type for filtering |
+| `group` | string | Yes | Working group / cell |
+| `tags` | string | Yes | Comma-separated tag list |
+| `release` | string | Yes | Creative release identifier |
+| `status` | string | Yes | Status (for questions, projects) |
+| `date` | number | Yes | Unix timestamp in milliseconds |
+| `path` | string | No | R2 object key for document fetch |
+| `title` | string | No | Document title for display |
+| `description` | string | No | Description for display |
+| `content` | string | No | Truncated body for reranking (~8KB max) |
+
+6 indexed fields out of the Vectorize maximum of 10.
+
+**`truncateForMetadata()`** clips content to 8000 characters at the nearest word boundary, appending `...` if truncated. This leaves approximately 2 KiB for the other metadata fields within the 10 KiB limit.
+
+**`generateId()`** extracts the filename without extension from a path (e.g., `artifacts/patterns/cell-governance.md` → `cell-governance`). Throws if the resulting ID exceeds 64 bytes (Vectorize limit).
+
+**R2 key convention:** `content/{contentType}/{id}.json` — e.g., `content/pattern/cell-governance.json`. This allows both individual lookups and prefix-based listing by content type.
+
+#### Dependencies
+- **Internal:** `./content` (ContentTypeSchema, ContentType)
+- **External:** `@hono/zod-openapi`
+
+---
+
+### `sync.ts`
+
+**Purpose:** Defines payload types for the sync pipeline: workflow params, R2 events, GitHub webhooks, and parsed markdown.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `SyncParamsSchema` | Zod object | Workflow input: `{ changedFiles: string[], deletedFiles: string[], commitSha: string }` |
+| `SyncParams` | Type | Inferred type |
+| `R2EventNotification` | Interface | R2 bucket event: `{ account, bucket, object: { key, size, eTag }, eventType, eventTime }` |
+| `GitHubPushEvent` | Interface | Subset of GitHub push webhook: `{ ref, after, commits: [{ added, modified, removed }] }` |
+| `ParsedMarkdown` | Interface | `{ frontmatter: Record<string, unknown>, body: string }` |
+
+#### Internal Logic
+
+`R2EventNotification.eventType` is limited to `'object-create' | 'object-delete'` — these are the only events the queue consumer handles.
+
+`GitHubPushEvent` captures only the fields used by `handleWebhook()`: `ref` for branch filtering, `after` for the commit SHA, and `commits` for file change lists.
+
+#### Dependencies
+- **External:** `@hono/zod-openapi`
+
+---
+
+## Key Types
+
+| Type | Owner | Used By | Description |
+|------|-------|---------|-------------|
+| `ContentType` | `content.ts` | Everything | Union of 20 content type strings |
+| `R2Document` | `storage.ts` | `sync`, `consumers`, `retrieval`, `mcp`, `api` | The canonical document stored in R2 |
+| `VectorizeMetadata` | `storage.ts` | `consumers`, `retrieval` | Metadata attached to vectors |
+| `AuthContext` | `auth.ts` | `auth`, `mcp` | Resolved access context for a request |
+| `SearchResult` | `api.ts` | `retrieval`, `mcp`, `api` | Search result returned to clients |
+| `RerankResult` | `api.ts` | `retrieval` | Internal reranked result shape |
+| `SyncParams` | `sync.ts` | `sync` | Workflow input payload |
+
+## Configuration and Limits
+
+| Constant | Value | Source |
+|----------|-------|--------|
+| `VECTORIZE_LIMITS.METADATA_MAX_BYTES` | 10,240 (10 KiB) | Cloudflare Vectorize |
+| `VECTORIZE_LIMITS.VECTOR_ID_MAX_BYTES` | 64 | Cloudflare Vectorize |
+| `VECTORIZE_LIMITS.TOP_K_WITH_METADATA` | 20 | Cloudflare Vectorize |
+| `VECTORIZE_LIMITS.TOP_K_WITHOUT_METADATA` | 100 | Cloudflare Vectorize |
+| `VECTORIZE_LIMITS.MAX_METADATA_INDEXES` | 10 | Cloudflare Vectorize |
+| `VECTORIZE_NAMESPACE` | `'superbenefit'` | Application config |
+| `MAX_CONTENT_LENGTH` (internal) | 8,000 | Leaves ~2 KiB for other metadata fields |
+
+## Extension Points
+
+**Adding a new content type:**
+1. Add the type literal to `ContentTypeSchema` enum in `content.ts`
+2. Create a concrete schema extending the appropriate parent (`ResourceSchema`, `StorySchema`, etc.)
+3. Add the type to the relevant `*_TYPES` array
+4. Add a path prefix mapping to `PATH_TYPE_MAP`
+5. Add the schema to the `ContentSchema` discriminated union
+6. Export the schema and type from `index.ts`
+
+**Adding a new Vectorize metadata field:**
+1. Add the field to `VectorizeMetadataSchema` in `storage.ts`
+2. If indexed, count total indexed fields (max 10) and create the index via `wrangler vectorize create-metadata-index`
+3. Update `updateVectorize()` in `src/consumers/vectorize.ts` to populate the field
+4. Ensure total metadata stays under 10 KiB
+
+## Cross-References
+
+- [auth.md](auth.md) — How `AccessTier` and `AuthContext` are used for access control
+- [retrieval.md](retrieval.md) — How `SearchFilters`, `SearchResult`, and `VectorizeMetadata` drive search
+- [consumers.md](consumers.md) — How `R2Document` is transformed into `VectorizeMetadata`
+- [sync.md](sync.md) — How `SyncParams` and `ParsedMarkdown` drive the sync pipeline
+- `docs/spec.md` sections 2-8 — Full specification for each type category


### PR DESCRIPTION
## Summary

- Adds 8 documentation pages in `docs/src/`, one per `src/` directory, covering all 26 TypeScript source files
- Each page follows a consistent template: overview, mermaid data flow diagram, file-by-file reference with export tables, key types, Cloudflare bindings, configuration/limits, error handling, extension points, and cross-references
- Pages written in dependency order (types → auth → retrieval → consumers → sync → mcp → api → index) with all internal links verified
- Updates `README.md` with links to the new documentation section

## Test plan

- [ ] Verify all 8 markdown files render correctly on GitHub (especially mermaid diagrams)
- [ ] Spot-check export tables against actual source files
- [ ] Confirm all cross-reference links between doc pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)