### PR TITLE
docs: relocate module docs to README.md in src/ directories

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -28,7 +28,7 @@ graph TD
     Fetch -->|"POST /webhook"| WH["handleWebhook()<br/>Direct — bypasses Hono"]
     Fetch -->|everything else| Hono["Hono Router"]
 
-    Hono -->|"/api/v1/*"| API["api routes<br/>(see api.md)"]
+    Hono -->|"/api/v1/*"| API["api routes<br/>(see api/)"]
     Hono -->|unmatched| 404["Hono 404"]
 
     WH --> Verify["verifyWebhookSignature()"]
@@ -202,10 +202,10 @@ All bindings are used by this module or the modules it delegates to. See the Com
 
 ## Cross-References
 
-- [api.md](api.md) — REST API mounted at `/api/v1`
-- [mcp.md](mcp.md) — MCP server at `/mcp`
-- [sync.md](sync.md) — `KnowledgeSyncWorkflow`, `verifyWebhookSignature()`, `isExcluded()`
-- [consumers.md](consumers.md) — `handleVectorizeQueue()` wired to the `queue` export
-- [types.md](types.md) — `GitHubPushEvent`, `Env` interface
+- [api](api/) — REST API mounted at `/api/v1`
+- [mcp](mcp/) — MCP server at `/mcp`
+- [sync](sync/) — `KnowledgeSyncWorkflow`, `verifyWebhookSignature()`, `isExcluded()`
+- [consumers](consumers/) — `handleVectorizeQueue()` wired to the `queue` export
+- [types](types/) — `GitHubPushEvent`, `Env` interface
 - `CLAUDE.md` — Router integration pattern
 - `docs/spec.md` sections 1, 5.1, 8, 9 — Architecture, webhook handling, REST API, worker configuration

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -186,7 +186,7 @@ Response schemas are re-exported unchanged — they already have `.openapi()` an
 | `SearchResult` | `types/api.ts` | Search result shape |
 | `ContentType` | `types/content.ts` | Valid content type for path/query params |
 
-See [types.md](types.md) for full definitions.
+See [types](../types/) for full definitions.
 
 ## Cloudflare Bindings Used
 
@@ -263,7 +263,7 @@ curl -I -X OPTIONS http://localhost:8788/api/v1/entries \
 
 ## Cross-References
 
-- [types.md](types.md) — `ListParams`, `SearchParams`, `SearchResult`, `R2Document`, `ErrorResponse`
-- [retrieval.md](retrieval.md) — `searchKnowledge()` pipeline used by the search route
-- [index.md](index.md) — Where the API is mounted at `/api/v1`
+- [types](../types/) — `ListParams`, `SearchParams`, `SearchResult`, `R2Document`, `ErrorResponse`
+- [retrieval](../retrieval/) — `searchKnowledge()` pipeline used by the search route
+- [index](../) — Where the API is mounted at `/api/v1`
 - `docs/spec.md` sections 8, 10 — REST API and error handling specification

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -142,7 +142,7 @@ const userId = access.authContext.identity?.userId;
 | `TIER_LEVEL` | `types/auth.ts` | `{ open: 0, public: 1, members: 2 }` |
 | `TierAccessResult` | `check.ts` (local) | Discriminated union on `allowed` |
 
-See [types.md](types.md) for full type definitions.
+See [types](../types/) for full type definitions.
 
 ## Cloudflare Bindings Used
 
@@ -184,7 +184,7 @@ When access is denied, MCP tools return:
 
 ## Cross-References
 
-- [types.md](types.md) — `AccessTier`, `AuthContext`, `Identity` type definitions
-- [mcp.md](mcp.md) — How tools use the guard pattern with `resolveAuthContext()` + `checkTierAccess()`
+- [types](../types/) — `AccessTier`, `AuthContext`, `Identity` type definitions
+- [mcp](../mcp/) — How tools use the guard pattern with `resolveAuthContext()` + `checkTierAccess()`
 - `CLAUDE.md` — Guard boilerplate snippet
 - `docs/spec.md` section 2 — Full porch access control specification

--- a/src/consumers/README.md
+++ b/src/consumers/README.md
@@ -14,7 +14,7 @@
 
 The consumers directory contains a single queue consumer that bridges R2 storage and Vectorize search. When the sync workflow writes or deletes a document in R2, the R2 bucket emits an event notification to a Cloudflare Queue. This consumer processes those events, generating embeddings for new/updated documents and removing vectors for deleted ones.
 
-This is the write-side counterpart to the [retrieval module](retrieval.md)'s read-side search pipeline. Together they form a complete index: sync writes to R2, R2 events trigger this consumer, the consumer writes to Vectorize, and the retrieval module reads from Vectorize.
+This is the write-side counterpart to the [retrieval module](../retrieval/)'s read-side search pipeline. Together they form a complete index: sync writes to R2, R2 events trigger this consumer, the consumer writes to Vectorize, and the retrieval module reads from Vectorize.
 
 The consumer is designed for idempotency — upserting the same document ID overwrites the previous vector, and deleting a non-existent ID is a no-op. This is critical because R2 event notifications have no ordering guarantee.
 
@@ -125,7 +125,7 @@ The `ConsumerDeps` interface abstracts bindings for testability. `updateVectoriz
 | `R2EventNotification` | `vectorize.ts` (local) | R2 bucket event payload |
 | `ConsumerDeps` | `vectorize.ts` (local) | Binding interface for dependency injection |
 
-See [types.md](types.md) for full schema definitions.
+See [types](../types/) for full schema definitions.
 
 ## Cloudflare Bindings Used
 
@@ -176,8 +176,8 @@ Failed to process queue message {msg.id}: {error.message}
 
 ## Cross-References
 
-- [types.md](types.md) — `R2Document`, `VectorizeMetadata` schemas
-- [retrieval.md](retrieval.md) — The read-side counterpart that queries the Vectorize index
-- [sync.md](sync.md) — The workflow that writes to R2, triggering the events this consumer processes
-- [index.md](index.md) — Where `handleVectorizeQueue` is wired to the worker's `queue` export
+- [types](../types/) — `R2Document`, `VectorizeMetadata` schemas
+- [retrieval](../retrieval/) — The read-side counterpart that queries the Vectorize index
+- [sync](../sync/) — The workflow that writes to R2, triggering the events this consumer processes
+- [index](../) — Where `handleVectorizeQueue` is wired to the worker's `queue` export
 - `docs/spec.md` sections 4.3-4.4, 5.3 — Vectorize indexing and event processing specification

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -288,9 +288,9 @@ All tools follow the same error pattern:
 
 ## Cross-References
 
-- [auth.md](auth.md) — Porch access control guard pattern
-- [retrieval.md](retrieval.md) — `searchKnowledge()` pipeline called by search tools
-- [types.md](types.md) — `ContentType`, `SearchFilters`, `R2Document` schemas
-- [index.md](index.md) — Routing `/mcp` to `McpHandler`
+- [auth](../auth/) — Porch access control guard pattern
+- [retrieval](../retrieval/) — `searchKnowledge()` pipeline called by search tools
+- [types](../types/) — `ContentType`, `SearchFilters`, `R2Document` schemas
+- [index](../) — Routing `/mcp` to `McpHandler`
 - `CLAUDE.md` — Guard boilerplate snippet
 - `docs/spec.md` sections 7.3-7.5 — Full MCP primitive specifications

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -210,7 +210,7 @@ The `options` parameter currently only supports `includeDocuments?: boolean`. Wh
 | `VectorizeMetadata` | `types/storage.ts` | Metadata on vectors, includes `content` snippet for reranking |
 | `VectorizeMatch` | Cloudflare types | Vectorize query result with `id`, `score`, `metadata` |
 
-See [types.md](types.md) for full definitions.
+See [types](../types/) for full definitions.
 
 ## Cloudflare Bindings Used
 
@@ -263,8 +263,8 @@ Errors are not caught within the retrieval module — they propagate to the call
 
 ## Cross-References
 
-- [types.md](types.md) — `SearchResult`, `RerankResult`, `VectorizeMetadata` schemas
-- [consumers.md](consumers.md) — How documents get indexed into Vectorize (the write side of this read pipeline)
-- [mcp.md](mcp.md) — `search_knowledge` and `search_with_documents` tools that call `searchKnowledge()`
-- [api.md](api.md) — `GET /search` route that calls `searchKnowledge()`
+- [types](../types/) — `SearchResult`, `RerankResult`, `VectorizeMetadata` schemas
+- [consumers](../consumers/) — How documents get indexed into Vectorize (the write side of this read pipeline)
+- [mcp](../mcp/) — `search_knowledge` and `search_with_documents` tools that call `searchKnowledge()`
+- [api](../api/) — `GET /search` route that calls `searchKnowledge()`
 - `docs/spec.md` sections 6.1-6.3 — Full search pipeline specification

--- a/src/sync/README.md
+++ b/src/sync/README.md
@@ -39,7 +39,7 @@ graph LR
 
     WF -->|deleted files| Del["R2.delete()<br/>inferContentType + generateId"]
 
-    Store -->|R2 event| Queue["Queue → Vectorize<br/>(see consumers.md)"]
+    Store -->|R2 event| Queue["Queue → Vectorize<br/>(see consumers/)"]
 ```
 
 ## File-by-File Reference
@@ -191,7 +191,7 @@ Fetches file content from the GitHub Contents API:
 | `GitHubPushEvent` | `types/sync.ts` | Subset of GitHub push webhook payload |
 | `ContentType` | `types/content.ts` | 20-type union |
 
-See [types.md](types.md) for full definitions.
+See [types](../types/) for full definitions.
 
 ## Cloudflare Bindings Used
 
@@ -248,7 +248,7 @@ See [types.md](types.md) for full definitions.
 
 ## Cross-References
 
-- [types.md](types.md) — `SyncParams`, `R2Document`, `ParsedMarkdown`, `ContentType` definitions
-- [consumers.md](consumers.md) — Queue consumer that processes R2 events after sync writes
-- [index.md](index.md) — `handleWebhook()` function and `KnowledgeSyncWorkflow` re-export
+- [types](../types/) — `SyncParams`, `R2Document`, `ParsedMarkdown`, `ContentType` definitions
+- [consumers](../consumers/) — Queue consumer that processes R2 events after sync writes
+- [index](../) — `handleWebhook()` function and `KnowledgeSyncWorkflow` re-export
 - `docs/spec.md` section 5 — Full sync pipeline specification

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -357,8 +357,8 @@ The `SearchFiltersSchema` is shared between REST API and MCP tools — both use 
 
 ## Cross-References
 
-- [auth.md](auth.md) — How `AccessTier` and `AuthContext` are used for access control
-- [retrieval.md](retrieval.md) — How `SearchFilters`, `SearchResult`, and `VectorizeMetadata` drive search
-- [consumers.md](consumers.md) — How `R2Document` is transformed into `VectorizeMetadata`
-- [sync.md](sync.md) — How `SyncParams` and `ParsedMarkdown` drive the sync pipeline
+- [auth](../auth/) — How `AccessTier` and `AuthContext` are used for access control
+- [retrieval](../retrieval/) — How `SearchFilters`, `SearchResult`, and `VectorizeMetadata` drive search
+- [consumers](../consumers/) — How `R2Document` is transformed into `VectorizeMetadata`
+- [sync](../sync/) — How `SyncParams` and `ParsedMarkdown` drive the sync pipeline
 - `docs/spec.md` sections 2-8 — Full specification for each type category


### PR DESCRIPTION
## Summary
- Move documentation from `docs/src/*.md` to `README.md` files within each module directory
- Update cross-references to use relative paths between directories
- Places documentation closer to the code it describes

## Files moved
| Old Location | New Location |
|--------------|--------------|
| `docs/src/api.md` | `src/api/README.md` |
| `docs/src/auth.md` | `src/auth/README.md` |
| `docs/src/consumers.md` | `src/consumers/README.md` |
| `docs/src/index.md` | `src/README.md` |
| `docs/src/mcp.md` | `src/mcp/README.md` |
| `docs/src/retrieval.md` | `src/retrieval/README.md` |
| `docs/src/sync.md` | `src/sync/README.md` |
| `docs/src/types.md` | `src/types/README.md` |

## Test plan
- [ ] Verify all README files render correctly on GitHub
- [ ] Verify cross-reference links work between directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)