### PR TITLE
fix(security): implement security audit remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@hono/zod-openapi": "^1.2.0",
 				"agents": "^0.3.6",
-				"hono": "^4.11.7",
+				"hono": "^4.11.9",
 				"yaml": "^2.8.2",
 				"zod": "^4.3.6"
 			},
@@ -21,18 +21,10 @@
 				"wrangler": "^4.61.1"
 			}
 		},
-		"node_modules/@adraffy/ens-normalize": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-			"integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@ai-sdk/gateway": {
-			"version": "3.0.37",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.37.tgz",
-			"integrity": "sha512-w7rxPd2WOuSr4he2ALvtCAM/W1/33rGdv3kkU52tCGj/bJSYJnJDpnTvoWRLNESp9HEkkiNFfBLFZY0PB9n4aQ==",
+			"version": "3.0.39",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.39.tgz",
+			"integrity": "sha512-SeCZBAdDNbWpVUXiYgOAqis22p5MEYfrjRw0hiBa5hM+7sDGYQpMinUjkM8kbPXMkY+AhKLrHleBl+SuqpzlgA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -117,12 +109,12 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+			"integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.43.0"
+				"core-js-pure": "^3.48.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -189,9 +181,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260128.0.tgz",
-			"integrity": "sha512-XJN8zWWNG3JwAUqqwMLNKJ9fZfdlQkx/zTTHW/BB8wHat9LjKD6AzxqCu432YmfjR+NxEKCzUOxMu1YOxlVxmg==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260205.0.tgz",
+			"integrity": "sha512-ToOItqcirmWPwR+PtT+Q4bdjTn/63ZxhJKEfW4FNn7FxMTS1Tw5dml0T0mieOZbCpcvY8BdvPKFCSlJuI8IVHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -206,9 +198,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260128.0.tgz",
-			"integrity": "sha512-vKnRcmnm402GQ5DOdfT5H34qeR2m07nhnTtky8mTkNWP+7xmkz32AMdclwMmfO/iX9ncyKwSqmml2wPG32eq/w==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260205.0.tgz",
+			"integrity": "sha512-402ZqLz+LrG0NDXp7Hn7IZbI0DyhjNfjAlVenb0K3yod9KCuux0u3NksNBvqJx0mIGHvVR4K05h+jfT5BTHqGA==",
 			"cpu": [
 				"arm64"
 			],
@@ -223,9 +215,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260128.0.tgz",
-			"integrity": "sha512-RiaR+Qugof/c6oI5SagD2J5wJmIfI8wQWaV2Y9905Raj6sAYOFaEKfzkKnoLLLNYb4NlXicBrffJi1j7R/ypUA==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260205.0.tgz",
+			"integrity": "sha512-rz9jBzazIA18RHY+osa19hvsPfr0LZI1AJzIjC6UqkKKphcTpHBEQ25Xt8cIA34ivMIqeENpYnnmpDFesLkfcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -240,9 +232,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260128.0.tgz",
-			"integrity": "sha512-U39U9vcXLXYDbrJ112Q7D0LDUUnM54oXfAxPgrL2goBwio7Z6RnsM25TRvm+Q06F4+FeDOC4D51JXlFHb9t1OA==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260205.0.tgz",
+			"integrity": "sha512-jr6cKpMM/DBEbL+ATJ9rYue758CKp0SfA/nXt5vR32iINVJrb396ye9iat2y9Moa/PgPKnTrFgmT6urUmG3IUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -257,9 +249,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260128.0.tgz",
-			"integrity": "sha512-fdJwSqRkJsAJFJ7+jy0th2uMO6fwaDA8Ny6+iFCssfzlNkc4dP/twXo+3F66FMLMe/6NIqjzVts0cpiv7ERYbQ==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260205.0.tgz",
+			"integrity": "sha512-SMPW5jCZYOG7XFIglSlsgN8ivcl0pCrSAYxCwxtWvZ88whhcDB/aISNtiQiDZujPH8tIo2hE5dEkxW7tGEwc3A==",
 			"cpu": [
 				"x64"
 			],
@@ -274,9 +266,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260128.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260128.0.tgz",
-			"integrity": "sha512-oid8qPnF4K5Wmgf66bUUrGycwL8BOCGm9ptQOoQNR/jhY5TmDObLtPjJm+BmDklkpAkaM1FnqKY9lo+FNo78AA==",
+			"version": "4.20260210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260210.0.tgz",
+			"integrity": "sha512-zHaF0RZVYUQwNCJCECnNAJdMur72Lk3FMiD6wU78Dx3Bv7DQRcuXNmPNuJmsGnosVZCcWintHlPTQ/4BEiDG5w==",
 			"license": "MIT OR Apache-2.0",
 			"peer": true
 		},
@@ -759,9 +751,9 @@
 			}
 		},
 		"node_modules/@hono/zod-openapi": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-1.2.0.tgz",
-			"integrity": "sha512-KDfHqv/Wy4elVseZXgokbHxeWuqBL+AZfqsOMpEihBMUsk/fJ+bLIi3Sf70JFVpt1Ihui8RasYrInozt7ZBDIA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-1.2.1.tgz",
+			"integrity": "sha512-aZza4V8wkqpdHBWFNPiCeWd0cGOXbYuQW9AyezHs/jwQm5p67GkUyXwfthAooAwnG7thTpvOJkThZpCoY6us8w==",
 			"license": "MIT",
 			"dependencies": {
 				"@asteasolutions/zod-to-openapi": "^8.1.0",
@@ -1350,51 +1342,6 @@
 				}
 			}
 		},
-		"node_modules/@noble/ciphers": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-			"integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@noble/curves": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-			"integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@noble/hashes": "1.8.0"
-			},
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@noble/hashes": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1433,48 +1380,6 @@
 			"integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@scure/base": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@scure/bip32": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-			"integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@noble/curves": "~1.9.0",
-				"@noble/hashes": "~1.8.0",
-				"@scure/base": "~1.2.5"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@scure/bip39": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-			"integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@noble/hashes": "~1.8.0",
-				"@scure/base": "~1.2.5"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "7.2.0",
@@ -1516,9 +1421,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.2.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-			"integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+			"version": "25.2.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
+			"integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1533,29 +1438,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 20"
-			}
-		},
-		"node_modules/abitype": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
-			"integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/wevm"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4",
-				"zod": "^3.22.0 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				},
-				"zod": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/accepts": {
@@ -1619,13 +1501,13 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "6.0.75",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.75.tgz",
-			"integrity": "sha512-pT1xtwaE5Un261GO9Mt9DZ2rv26v+gQZNRXo433CNAMo0JDYs2ef+5MvcNkBe1jXCY9XrXxUG/VT6Y6/9S2SWg==",
+			"version": "6.0.78",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.78.tgz",
+			"integrity": "sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@ai-sdk/gateway": "3.0.37",
+				"@ai-sdk/gateway": "3.0.39",
 				"@ai-sdk/provider": "3.0.8",
 				"@ai-sdk/provider-utils": "4.0.14",
 				"@opentelemetry/api": "1.9.0"
@@ -2057,14 +1939,6 @@
 			"integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
 			"license": "MIT"
 		},
-		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/eventsource": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -2344,9 +2218,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.11.7",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-			"integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+			"integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -2444,23 +2318,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
-		},
-		"node_modules/isows": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
-			"integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"peerDependencies": {
-				"ws": "*"
-			}
 		},
 		"node_modules/jose": {
 			"version": "6.1.3",
@@ -2639,16 +2496,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260128.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260128.0.tgz",
-			"integrity": "sha512-AVCn3vDRY+YXu1sP4mRn81ssno6VUqxo29uY2QVfgxXU2TMLvhRIoGwm7RglJ3Gzfuidit5R86CMQ6AvdFTGAw==",
+			"version": "4.20260205.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260205.0.tgz",
+			"integrity": "sha512-jG1TknEDeFqcq/z5gsOm1rKeg4cNG7ruWxEuiPxl3pnQumavxo8kFpeQC6XKVpAhh2PI9ODGyIYlgd77sTHl5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
 				"undici": "7.18.2",
-				"workerd": "1.20260128.0",
+				"workerd": "1.20260205.0",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -2752,38 +2609,6 @@
 				"yaml": "^2.8.0"
 			}
 		},
-		"node_modules/ox": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
-			"integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@adraffy/ens-normalize": "^1.11.0",
-				"@noble/ciphers": "^1.3.0",
-				"@noble/curves": "1.9.1",
-				"@noble/hashes": "^1.8.0",
-				"@scure/bip32": "^1.7.0",
-				"@scure/bip39": "^1.6.0",
-				"abitype": "^1.2.3",
-				"eventemitter3": "5.0.1"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.4.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2794,9 +2619,9 @@
 			}
 		},
 		"node_modules/partyserver": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.1.2.tgz",
-			"integrity": "sha512-9ca0wnl8JPYUzPZst76dNndnLxHPnqUHnpYeVa7/+k3rzQeFuPkI9InqOanupkVmEvRTW2/HIKu/wfAeAqTorw==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.1.5.tgz",
+			"integrity": "sha512-kaE3GYaYWFc70EJQDQEhyYbO2Wczz/NgsFXerfjRo0t2s7ZxL1XggWT+HkMrdEyqbZOv3b66CV93WG0Lcg/ThQ==",
 			"license": "ISC",
 			"dependencies": {
 				"nanoid": "^5.1.6"
@@ -2970,9 +2795,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3330,61 +3155,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/viem": {
-			"version": "2.45.1",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.45.1.tgz",
-			"integrity": "sha512-LN6Pp7vSfv50LgwhkfSbIXftAM5J89lP9x8TeDa8QM7o41IxlHrDh0F9X+FfnCWtsz11pEVV5sn+yBUoOHNqYA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@noble/curves": "1.9.1",
-				"@noble/hashes": "1.8.0",
-				"@scure/bip32": "1.7.0",
-				"@scure/bip39": "1.6.0",
-				"abitype": "1.2.3",
-				"isows": "1.0.7",
-				"ox": "0.11.3",
-				"ws": "8.18.3"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/viem/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3401,9 +3171,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260128.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260128.0.tgz",
-			"integrity": "sha512-EhLJGptSGFi8AEErLiamO3PoGpbRqL+v4Ve36H2B38VxmDgFOSmDhfepBnA14sCQzGf1AEaoZX2DCwZsmO74yQ==",
+			"version": "1.20260205.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260205.0.tgz",
+			"integrity": "sha512-CcMH5clHwrH8VlY7yWS9C/G/C8g9czIz1yU3akMSP9Z3CkEMFSoC3GGdj5G7Alw/PHEeez1+1IrlYger4pwu+w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -3414,17 +3184,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260128.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20260128.0",
-				"@cloudflare/workerd-linux-64": "1.20260128.0",
-				"@cloudflare/workerd-linux-arm64": "1.20260128.0",
-				"@cloudflare/workerd-windows-64": "1.20260128.0"
+				"@cloudflare/workerd-darwin-64": "1.20260205.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20260205.0",
+				"@cloudflare/workerd-linux-64": "1.20260205.0",
+				"@cloudflare/workerd-linux-arm64": "1.20260205.0",
+				"@cloudflare/workerd-windows-64": "1.20260205.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.61.1.tgz",
-			"integrity": "sha512-hfYQ16VLPkNi8xE1/V3052S2stM5e+vq3Idpt83sXoDC3R7R1CLgMkK6M6+Qp3G+9GVDNyHCkvohMPdfFTaD4Q==",
+			"version": "4.63.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.63.0.tgz",
+			"integrity": "sha512-+R04jF7Eb8K3KRMSgoXpcIdLb8GC62eoSGusYh1pyrSMm/10E0hbKkd7phMJO4HxXc6R7mOHC5SSoX9eof30Uw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -3432,10 +3202,10 @@
 				"@cloudflare/unenv-preset": "2.12.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.0",
-				"miniflare": "4.20260128.0",
+				"miniflare": "4.20260205.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260128.0"
+				"workerd": "1.20260205.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -3448,7 +3218,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260128.0"
+				"@cloudflare/workers-types": "^4.20260205.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -3490,7 +3260,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"@hono/zod-openapi": "^1.2.0",
 		"agents": "^0.3.6",
-		"hono": "^4.11.7",
+		"hono": "^4.11.9",
 		"yaml": "^2.8.2",
 		"zod": "^4.3.6"
 	},

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -13,6 +13,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
+// TODO Phase 2: Add checkTierAccess() before prompt orchestration
+// Prompts can orchestrate tools without tier validation. When auth is added,
+// prompts should validate access before generating tool invocation messages.
+
 export function registerPrompts(server: McpServer, _env: Env): void {
   // Research workflow
   server.prompt(

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -93,6 +93,10 @@ const ONTOLOGY_SCHEMA = {
 // Resource registration
 // ---------------------------------------------------------------------------
 
+// TODO Phase 2: Add checkTierAccess() to all resource handlers
+// Similar pattern to tools.ts authorization. Resources currently bypass
+// tier access checks - Phase 2/3 could expose restricted data without auth.
+
 export function registerResources(server: McpServer, env: Env): void {
   // System prompt for knowledge search
   server.resource(

--- a/src/sync/github.ts
+++ b/src/sync/github.ts
@@ -87,6 +87,8 @@ export async function fetchFileContent(
       Accept: 'application/vnd.github.v3+json',
       'User-Agent': 'superbenefit-knowledge-server',
     },
+    // Security: Timeout to prevent hanging on slow/unresponsive API
+    signal: AbortSignal.timeout(10000),
   });
 
   if (!resp.ok) {

--- a/src/sync/parser.ts
+++ b/src/sync/parser.ts
@@ -30,7 +30,11 @@ export function parseMarkdown(raw: string): ParsedMarkdown {
   let frontmatter: Record<string, unknown>;
 
   try {
-    frontmatter = parseYaml(yamlBlock) ?? {};
+    // Security: Limit YAML size and alias depth to prevent DoS (billion laughs attack)
+    if (yamlBlock.length > 10000) {
+      throw new Error('YAML frontmatter too large');
+    }
+    frontmatter = parseYaml(yamlBlock, { maxAliasCount: 10 }) ?? {};
   } catch {
     frontmatter = {};
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -29,7 +29,7 @@ export type ListParams = z.infer<typeof ListParamsSchema>;
 // Search query params (spec section 8.3)
 export const SearchParamsSchema = z
   .object({
-    q: z.string().min(1),
+    q: z.string().min(1).max(5000),
     contentType: ContentTypeSchema.optional(),
     group: z.string().optional(),
     release: z.string().optional(),

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -100,6 +100,10 @@ export function generateId(path: string): string {
  * Example: ("pattern", "cell-governance") → "content/pattern/cell-governance.json"
  */
 export function toR2Key(contentType: ContentType, id: string): string {
+  // Security: Prevent path traversal attacks
+  if (id.includes('..') || id.includes('/') || id.includes('\\')) {
+    throw new Error(`Invalid characters in document ID: ${id}`);
+  }
   return `content/${contentType}/${id}.json`;
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "knowledge-server",
-	"account_id": "c36c9a59f6251430c514f4fff55c3f4a",
+	// account_id removed for security - use CLOUDFLARE_ACCOUNT_ID env var
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
 	"compatibility_flags": [


### PR DESCRIPTION
## Summary

Implements all 17 security findings from the February 9, 2026 audit:

- **2 CRITICAL**: Remove exposed account_id, add Zod validation for Vectorize metadata
- **5 HIGH**: SHA-256 cache keys, webhook replay protection, YAML DoS limits, security headers, remove DELETE from MCP CORS
- **4 MEDIUM**: userId validation, path traversal prevention, queue message validation, query length limit
- **3 LOW**: Sanitized error logging, Hono upgrade, GitHub API timeout
- **3 Phase 2/3 prep**: TODO markers for auth and rate-limiting

## Changes by file

| File | Fixes |
|------|-------|
| wrangler.jsonc | C1: Remove account_id |
| src/retrieval/rerank.ts | C2: Zod metadata validation, H1: SHA-256 hash |
| src/index.ts | H2: Webhook replay protection, H5: Remove DELETE |
| src/sync/parser.ts | H3: YAML size/alias limits |
| src/api/routes.ts | H4: Security headers, L1: Error sanitization |
| src/mcp/tools.ts | M3: userId validation, M6: Rate limit TODO |
| src/types/storage.ts | M4: Path traversal check |
| src/consumers/vectorize.ts | M5: Queue message schema |
| src/types/api.ts | M7: Query max length |
| src/sync/github.ts | L3: Fetch timeout |
| package.json | L2: Hono 4.11.9 |
| src/mcp/resources.ts | M1: Auth TODO |
| src/mcp/prompts.ts | M2: Auth TODO |

## Test plan

- [x] Type check passes (`npm run type-check`)
- [x] Dev server starts (`npm run dev`)
- [x] MCP endpoint responds to curl with correct headers
- [x] CORS headers verified (no DELETE in MCP endpoint)
- [ ] Deploy to staging and verify production behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)