### PR TITLE
feat: add Scalar API docs UI and root info endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@hono/zod-openapi": "^1.2.0",
+				"@scalar/hono-api-reference": "^0.9.44",
 				"@superbenefit/porch": "github:superbenefit/mcporch",
 				"agents": "^0.3.6",
 				"hono": "^4.11.9",
@@ -1732,6 +1733,57 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@scalar/core": {
+			"version": "0.3.41",
+			"resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.3.41.tgz",
+			"integrity": "sha512-IPgiHOSGBDfBcJELbev0lo+ZHc8Q/vA82neX0Ax1iHNGtf/munH+qN5I+p9rGRS60IRQAwABlUo31Y3Gw1c0EA==",
+			"license": "MIT",
+			"dependencies": {
+				"@scalar/types": "0.6.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@scalar/helpers": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.15.tgz",
+			"integrity": "sha512-hMHXejGFVOS4HwCo7C2qddChuvMJs3sEOALo7gNOvwLS4dGLrW8flbSglDki4ttyremlKQstP5WJuPxmHQU3sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@scalar/hono-api-reference": {
+			"version": "0.9.44",
+			"resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.9.44.tgz",
+			"integrity": "sha512-NusQ3S/LYKmEMOwc5kbKi6Can1b0iHTL/145CxfT5klEXtazhzdiXtYNiPNS99vGYKjub7+oaFR/HXJz4y/w2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@scalar/core": "0.3.41"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"hono": "^4.11.5"
+			}
+		},
+		"node_modules/@scalar/types": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.6.6.tgz",
+			"integrity": "sha512-nr3m23p5MnGy4Wb4JFT7aA+jzvYSs/AS40NUEoQMBE1IwtuvG5gtLL0uu6kWpDq4UAfrWGntlAQNX7G8X9D4sg==",
+			"license": "MIT",
+			"dependencies": {
+				"@scalar/helpers": "0.2.15",
+				"nanoid": "^5.1.6",
+				"type-fest": "^5.3.1",
+				"zod": "^4.3.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "7.2.0",
@@ -3814,6 +3866,18 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3890,6 +3954,21 @@
 			"dev": true,
 			"license": "0BSD",
 			"optional": true
+		},
+		"node_modules/type-fest": {
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+			"integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/type-is": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"@hono/zod-openapi": "^1.2.0",
+		"@scalar/hono-api-reference": "^0.9.44",
 		"@superbenefit/porch": "github:superbenefit/mcporch",
 		"agents": "^0.3.6",
 		"hono": "^4.11.9",

--- a/src/api/routes.test.ts
+++ b/src/api/routes.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { api } from './routes';
+
+describe('GET /docs', () => {
+  it('returns HTML with Scalar API reference', async () => {
+    const res = await api.request('/docs');
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('<!doctype html>');
+    expect(text).toContain('scalar');
+  });
+});
+
+describe('GET /openapi.json', () => {
+  it('returns OpenAPI 3.1 spec', async () => {
+    const res = await api.request('/openapi.json');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { openapi: string; info: { title: string } };
+    expect(json.openapi).toBe('3.1.0');
+    expect(json.info.title).toBe('SuperBenefit Knowledge API');
+  });
+});

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import { Scalar } from '@scalar/hono-api-reference';
 import { cors } from 'hono/cors';
 import { toR2Key } from '../types/storage';
 import type { R2Document } from '../types/storage';
@@ -253,3 +254,18 @@ api.doc('/openapi.json', {
     description: 'Public read-only API for the SuperBenefit knowledge base',
   },
 });
+
+// ---------------------------------------------------------------------------
+// GET /docs — Scalar API docs UI
+// ---------------------------------------------------------------------------
+
+// Override strict CSP for the docs page (Scalar loads from CDN)
+api.use('/docs', async (c, next) => {
+  await next();
+  c.header(
+    'Content-Security-Policy',
+    "default-src 'self'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline' https://cdn.jsdelivr.net; font-src https://cdn.jsdelivr.net; connect-src 'self'; img-src 'self' data: https://cdn.jsdelivr.net;",
+  );
+});
+
+api.get('/docs', Scalar({ url: '/api/v1/openapi.json', pageTitle: 'SuperBenefit Knowledge API' }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,21 @@ async function handleWebhook(request: Request, env: Env): Promise<Response> {
 
 const app = new Hono<{ Bindings: Env }>();
 
+// Root info endpoint
+app.get('/', (c) =>
+  c.json({
+    name: 'SuperBenefit Knowledge Server',
+    version: '0.1.0',
+    endpoints: {
+      api: '/api/v1',
+      docs: '/api/v1/docs',
+      openapi: '/api/v1/openapi.json',
+      mcp: '/mcp',
+      health: '/api/v1/health',
+    },
+  }),
+);
+
 // Public REST API (no auth required)
 app.route('/api/v1', api);
 


### PR DESCRIPTION
## Summary
- Add interactive API docs at `/api/v1/docs` via `@scalar/hono-api-reference` (CDN-loaded, zero bundle impact)
- Add `GET /` root endpoint returning JSON with server info and all available endpoints
- Route-specific CSP override allows Scalar CDN on docs page while keeping strict CSP on API routes
- Tests for docs UI and OpenAPI spec routes

## Test plan
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (63/63)
- [ ] `wrangler deploy --dry-run` succeeds
- [ ] Post-deploy: `curl https://knowledge-server.superbenefit.dev/` returns JSON info
- [ ] Post-deploy: `https://knowledge-server.superbenefit.dev/api/v1/docs` renders Scalar UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)