### PR TITLE
fix: CSP for Scalar docs, HTML landing page

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -33,7 +33,10 @@ api.onError((err, c) => {
 // Security headers middleware
 api.use('*', async (c, next) => {
   await next();
-  c.header('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'");
+  // Docs page needs a permissive CSP for Scalar CDN — handled by route-specific middleware
+  if (!c.req.path.endsWith('/docs')) {
+    c.header('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'");
+  }
   c.header('X-Content-Type-Options', 'nosniff');
   c.header('X-Frame-Options', 'DENY');
   c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,20 +91,72 @@ async function handleWebhook(request: Request, env: Env): Promise<Response> {
 
 const app = new Hono<{ Bindings: Env }>();
 
-// Root info endpoint
-app.get('/', (c) =>
-  c.json({
-    name: 'SuperBenefit Knowledge Server',
-    version: '0.1.0',
-    endpoints: {
-      api: '/api/v1',
-      docs: '/api/v1/docs',
-      openapi: '/api/v1/openapi.json',
-      mcp: '/mcp',
-      health: '/api/v1/health',
-    },
-  }),
-);
+// Root landing page
+app.get('/', (c) => {
+  // JSON for programmatic clients
+  if (c.req.header('Accept')?.includes('application/json')) {
+    return c.json({
+      name: 'SuperBenefit Knowledge Server',
+      version: '0.1.0',
+      endpoints: {
+        api: '/api/v1',
+        docs: '/api/v1/docs',
+        openapi: '/api/v1/openapi.json',
+        mcp: '/mcp',
+        health: '/api/v1/health',
+      },
+    });
+  }
+  // HTML for browsers
+  return c.html(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SuperBenefit Knowledge Server</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:system-ui,-apple-system,sans-serif;background:#0a0a0b;color:#e4e4e7;min-height:100vh;display:flex;align-items:center;justify-content:center}
+.container{max-width:540px;width:100%;padding:2rem}
+h1{font-size:1.5rem;font-weight:600;margin-bottom:.25rem}
+.subtitle{color:#a1a1aa;font-size:.875rem;margin-bottom:2rem}
+.version{display:inline-block;font-size:.75rem;color:#71717a;border:1px solid #27272a;border-radius:9999px;padding:.125rem .5rem;margin-left:.5rem;vertical-align:middle}
+.section{margin-bottom:1.5rem}
+.section-title{font-size:.75rem;font-weight:500;color:#71717a;text-transform:uppercase;letter-spacing:.05em;margin-bottom:.75rem}
+a{color:#e4e4e7;text-decoration:none;display:flex;align-items:center;gap:.75rem;padding:.625rem .875rem;border-radius:.5rem;border:1px solid #27272a;background:#18181b;margin-bottom:.5rem;transition:border-color .15s,background .15s}
+a:hover{border-color:#3f3f46;background:#1f1f23}
+.label{font-size:.875rem;font-weight:500}
+.path{font-size:.75rem;color:#71717a;font-family:ui-monospace,monospace}
+.dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.dot-green{background:#22c55e}
+.dot-blue{background:#3b82f6}
+.dot-purple{background:#a855f7}
+.footer{margin-top:2rem;padding-top:1rem;border-top:1px solid #1c1c1f;font-size:.75rem;color:#52525b}
+.footer a{display:inline;border:0;background:0;padding:0;color:#a855f7}
+.footer a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>Knowledge Server<span class="version">v0.1.0</span></h1>
+  <p class="subtitle">SuperBenefit knowledge base — public read-only API and MCP server</p>
+  <div class="section">
+    <div class="section-title">Endpoints</div>
+    <a href="/api/v1/docs"><span class="dot dot-green"></span><span><span class="label">API Documentation</span><br><span class="path">/api/v1/docs</span></span></a>
+    <a href="/api/v1/openapi.json"><span class="dot dot-blue"></span><span><span class="label">OpenAPI Spec</span><br><span class="path">/api/v1/openapi.json</span></span></a>
+    <a href="/api/v1/entries"><span class="dot dot-blue"></span><span><span class="label">Entries</span><br><span class="path">/api/v1/entries</span></span></a>
+    <a href="/api/v1/search?q=governance"><span class="dot dot-blue"></span><span><span class="label">Search</span><br><span class="path">/api/v1/search?q=…</span></span></a>
+    <a href="/api/v1/health"><span class="dot dot-green"></span><span><span class="label">Health</span><br><span class="path">/api/v1/health</span></span></a>
+  </div>
+  <div class="section">
+    <div class="section-title">MCP</div>
+    <a href="/mcp"><span class="dot dot-purple"></span><span><span class="label">MCP Server</span><br><span class="path">/mcp</span></span></a>
+  </div>
+  <div class="footer">Part of the <a href="https://superbenefit.org">SuperBenefit</a> knowledge stack</div>
+</div>
+</body>
+</html>`);
+});
 
 // Public REST API (no auth required)
 app.route('/api/v1', api);


### PR DESCRIPTION
## Summary
- Fix CSP header ordering — global middleware was overwriting the `/docs` route-specific CSP, preventing Scalar UI from loading
- Replace bare JSON root with dark-themed HTML landing page listing all endpoints
- Content negotiation: browsers get HTML, `Accept: application/json` gets JSON

## Test plan
- [ ] `npm run type-check` passes
- [ ] `npm test` passes (63/63)
- [ ] `https://knowledge-server.superbenefit.dev/api/v1/docs` loads Scalar interactive docs
- [ ] `https://knowledge-server.superbenefit.dev/` shows HTML landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)