### PR TITLE
feat: WorkerEntrypoint with RPC methods for service bindings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Building an MCP server + public REST API for SuperBenefit DAO that:
 
 ## Technical Stack
 
-- Cloudflare Workers (stateless `createMcpHandler`)
+- Cloudflare Workers (`WorkerEntrypoint` class with RPC methods + HTTP handlers)
 - Hono for HTTP routing + REST API
 - @hono/zod-openapi for OpenAPI generation
 - Vectorize for semantic search
@@ -26,11 +26,11 @@ Building an MCP server + public REST API for SuperBenefit DAO that:
 
 ### Strict Requirements
 
-- Always use `export default { fetch }` pattern or Hono app export
-- NEVER use `addEventListener('fetch', ...)`
+- Default export is `class KnowledgeServer extends WorkerEntrypoint<Env>` — uses `this.env` / `this.ctx`
+- NEVER use `addEventListener('fetch', ...)` or plain `export default { fetch }`
 - Use Web standard APIs (Request, Response, URL)
 - Import Cloudflare types from 'cloudflare:workers'
-- Environment accessed via second arg: `fetch(req, env)`
+- RPC methods use camelCase (e.g., `searchKnowledge`, `getDocument`)
 
 ### MCP Server Pattern (Porch Framework)
 
@@ -70,13 +70,14 @@ server.tool('my_tool', 'description', { param: z.string() },
 
 ```
 src/
-├── index.ts              # Main router (rate limiting, security headers, routing split)
+├── index.ts              # WorkerEntrypoint class (HTTP, queue, webhook, RPC methods)
 ├── types/
 │   ├── index.ts          # Re-exports all types (auth from @superbenefit/porch/auth)
 │   ├── content.ts        # 21 content type schemas, PATH_TYPE_MAP, inferContentType
 │   ├── api.ts            # API request/response types
 │   ├── storage.ts        # R2Document, VectorizeMetadata
-│   └── sync.ts           # SyncParams, R2EventNotification
+│   ├── sync.ts           # SyncParams, R2EventNotification
+│   └── rpc.ts            # RPC parameter/result types for service binding consumers
 ├── api/                  # Public REST API
 │   ├── routes.ts         # Hono + OpenAPI routes (health, entries, search, openapi)
 │   └── schemas.ts        # Zod schemas
@@ -130,23 +131,30 @@ const reranked = await env.AI.run('@cf/baai/bge-reranker-base', {
 });
 ```
 
-### Router Integration
+### WorkerEntrypoint + Router Integration
 
 ```typescript
-// src/index.ts — rate limiting + security headers + routing split
-import { SECURITY_HEADERS } from '@superbenefit/porch/security';
+// src/index.ts — WorkerEntrypoint with HTTP routing, queue, and RPC
+import { WorkerEntrypoint } from 'cloudflare:workers';
 
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    // Rate limiting on all requests (429 with SECURITY_HEADERS)
-    // MCP → createMcpHandler (direct, security headers injected)
-    // POST /webhook → handleWebhook (with replay protection via delivery ID)
-    // Everything else → Hono (REST API at /api/v1)
-    ...
-  },
-  queue: handleVectorizeQueue,
-};
+export default class KnowledgeServer extends WorkerEntrypoint<Env> {
+  async fetch(request: Request): Promise<Response> {
+    // Rate limiting → MCP → webhook → Hono (REST API)
+    // Uses this.env / this.ctx (not function args)
+  }
+  async queue(batch: MessageBatch<unknown>): Promise<void> { ... }
+  private async handleWebhook(request: Request): Promise<Response> { ... }
+
+  // RPC methods — callable via service bindings from other Workers
+  async searchKnowledge(params: SearchKnowledgeParams): Promise<SearchKnowledgeResult> { ... }
+  async getDocument(params: GetDocumentParams): Promise<R2Document | null> { ... }
+  async listGroups(): Promise<ListGroupsResult> { ... }
+  async listReleases(): Promise<ListReleasesResult> { ... }
+  async defineTerm(params: DefineTermParams): Promise<DefineTermResult> { ... }
+}
 ```
+
+Consumer apps call via service bindings: `await env.KNOWLEDGE_SERVER.searchKnowledge({ query: '...' })`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ Sync Layer: Webhook → Workflow → R2 → Event → Queue → Vectorize
          │
          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  Knowledge Server (Cloudflare Worker)                       │
+│  KnowledgeServer extends WorkerEntrypoint<Env>              │
 │                                                             │
-│  /api/v1/*           REST API (Hono + OpenAPI)              │
-│  /mcp                MCP Server (Tools, Resources, Prompts) │
-│  /webhook            GitHub push events                     │
+│  HTTP:                                                      │
+│    /api/v1/*         REST API (Hono + OpenAPI)              │
+│    /mcp              MCP Server (Tools, Resources, Prompts) │
+│    /webhook          GitHub push events                     │
+│                                                             │
+│  RPC (service bindings — zero-latency inter-Worker calls):  │
+│    searchKnowledge · getDocument · listGroups               │
+│    listReleases · defineTerm                                │
+│                                                             │
+│  Queue: R2 event notifications → Vectorize indexing         │
 │                                                             │
 │  Access: resolveAuthContext() → checkTierAccess()           │
 │  Phase 1: All tools Open tier (no auth)                     │
@@ -69,9 +76,8 @@ curl -I -X OPTIONS http://localhost:8788/api/v1/entries \
 
 ```
 src/
-├── index.ts              # Entry point + routing (MCP, REST, webhook)
-├── types/                # Type system + content ontology
-├── auth/                 # Porch access control framework
+├── index.ts              # WorkerEntrypoint class (HTTP, queue, RPC)
+├── types/                # Type system + content ontology + RPC types
 ├── api/                  # REST API routes + OpenAPI
 ├── mcp/                  # MCP server (tools, resources, prompts)
 ├── retrieval/            # Three-stage search pipeline

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
 	"name": "superbenefit-knowledge-server",
 	"version": "0.0.1",
 	"private": true,
+	"exports": {
+		".": "./src/index.ts",
+		"./types": "./src/types/rpc.ts"
+	},
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",

--- a/src/README.md
+++ b/src/README.md
@@ -1,31 +1,38 @@
 # Index (Entry Point)
 
-> Main worker entry point — routes requests across MCP, REST API, and GitHub webhooks, and exports the queue consumer.
+> WorkerEntrypoint class — HTTP routing, queue consumer, webhook handler, and RPC methods for inter-Worker service bindings.
 
 **Source:** `src/index.ts`, `src/env.d.ts`
 **Files:** 2
-**Spec reference:** `docs/spec.md` sections 1, 5.1, 8, 9
-**Depends on:** `api` (Hono app), `mcp` (createMcpServer), `consumers` (handleVectorizeQueue), `sync` (verifyWebhookSignature, isExcluded, KnowledgeSyncWorkflow), `types` (GitHubPushEvent), `@superbenefit/porch/auth`, `@superbenefit/porch/security` (SECURITY_HEADERS)
-**Depended on by:** Cloudflare Workers runtime (worker entry point)
+**Spec reference:** `docs/spec.md` sections 1, 5.1, 8, 9; `tmp/worker-rpc.md` v0.17
+**Depends on:** `api` (Hono app), `mcp` (createMcpServer), `consumers` (handleVectorizeQueue), `retrieval` (searchKnowledge, getDocument), `sync` (verifyWebhookSignature, isExcluded, KnowledgeSyncWorkflow), `types` (GitHubPushEvent, RPC types), `@superbenefit/porch/security` (SECURITY_HEADERS)
+**Depended on by:** Cloudflare Workers runtime (worker entry point), consumer Workers via service bindings
 
 ---
 
 ## Overview
 
-The index module is the single entry point for the Cloudflare Worker. It handles two runtime entrypoints: `fetch` (HTTP requests) and `queue` (queue message batches). The fetch handler implements a three-way routing split that directs requests to specialized handlers before they reach Hono's general-purpose router.
+The index module exports `KnowledgeServer`, a `WorkerEntrypoint<Env>` class that serves as the single entry point for the Cloudflare Worker. The class provides three categories of interface:
 
-The routing split is intentional — MCP requests bypass Hono entirely to avoid middleware interference (MCP uses SSE and has its own CORS handling), while the REST API benefits from Hono's middleware stack (CORS, validation, OpenAPI generation). The webhook handler is also routed directly to avoid unnecessary middleware processing.
+1. **HTTP handlers** — `fetch()` implements a three-way routing split (MCP, webhook, Hono REST API) and `handleWebhook()` is a private class method for GitHub push events with `ctx.waitUntil()` for fire-and-forget workflow creation.
+2. **Queue consumer** — `queue()` delegates to `handleVectorizeQueue` for R2 event processing.
+3. **RPC methods** — Five public methods (`searchKnowledge`, `getDocument`, `listGroups`, `listReleases`, `defineTerm`) callable via service bindings from other Workers with zero HTTP overhead.
 
-The file also contains the `handleWebhook()` function, which validates GitHub push events and triggers the sync workflow. Finally, it re-exports `KnowledgeSyncWorkflow` at the module level so Cloudflare's runtime can discover it via the `class_name` configuration in `wrangler.jsonc`.
+The routing split is intentional — MCP requests bypass Hono entirely to avoid middleware interference (MCP uses SSE and has its own CORS handling), while the REST API benefits from Hono's middleware stack (CORS, validation, OpenAPI generation).
+
+The MCP handler is created per-request inside `fetch()` because `createMcpServer(this.env)` requires the class instance's `this.env`, which is unavailable at module scope. This is the correct pattern for `WorkerEntrypoint`.
+
+The file also re-exports `KnowledgeSyncWorkflow` at the module level so Cloudflare's runtime can discover it via the `class_name` configuration in `wrangler.jsonc`.
 
 ## Data Flow Diagram
 
 ```mermaid
 graph TD
-    Request["Incoming Request"] --> Fetch["export default { fetch }"]
+    Request["Incoming HTTP Request"] --> Fetch["KnowledgeServer.fetch()"]
+    RPC["Service Binding Call"] --> RPCMethods["RPC Methods<br/>searchKnowledge, getDocument,<br/>listGroups, listReleases, defineTerm"]
 
     Fetch -->|"/mcp" or "/mcp/*"| MCP["createMcpHandler()<br/>Direct — bypasses Hono"]
-    Fetch -->|"POST /webhook"| WH["handleWebhook()<br/>Direct — bypasses Hono"]
+    Fetch -->|"POST /webhook"| WH["this.handleWebhook()<br/>Private class method"]
     Fetch -->|everything else| Hono["Hono Router"]
 
     Hono -->|"/api/v1/*"| API["api routes<br/>(see api/)"]
@@ -36,74 +43,81 @@ graph TD
     Verify -->|valid| Branch{"ref === refs/heads/main?"}
     Branch -->|no| Ignore["{ status: 'ignored' }"]
     Branch -->|yes| Collect["Collect .md files<br/>filter excluded<br/>deduplicate"]
-    Collect --> Trigger["env.SYNC_WORKFLOW.create()"]
+    Collect --> Trigger["ctx.waitUntil(<br/>SYNC_WORKFLOW.create())"]
 
-    Queue["Queue Messages"] --> QueueHandler["export default { queue }<br/>handleVectorizeQueue()"]
+    Queue["Queue Messages"] --> QueueHandler["KnowledgeServer.queue()<br/>handleVectorizeQueue()"]
 ```
 
 ## File-by-File Reference
 
 ### `index.ts`
 
-**Purpose:** Main worker module — HTTP routing, webhook handling, and runtime exports.
+**Purpose:** WorkerEntrypoint class — HTTP routing, webhook handling, queue consumer, and RPC methods.
 
 #### Exports
 
 | Export | Kind | Description |
 |--------|------|-------------|
 | `KnowledgeSyncWorkflow` | Re-export (class) | From `./sync/workflow` — required for wrangler class_name discovery |
-| `default` | Object | `{ fetch, queue }` — Worker module entry point |
+| `default` | Class | `KnowledgeServer extends WorkerEntrypoint<Env>` — worker entry point |
+
+#### Class Methods
+
+| Method | Visibility | Description |
+|--------|-----------|-------------|
+| `fetch(request)` | public | HTTP routing — rate limiting, MCP, webhook, Hono REST API |
+| `queue(batch)` | public | Queue consumer — delegates to `handleVectorizeQueue` |
+| `handleWebhook(request)` | private | GitHub push event processing with `ctx.waitUntil()` |
+| `searchKnowledge(params)` | public (RPC) | Three-stage search pipeline — returns `{ items, total }` |
+| `getDocument(params)` | public (RPC) | Get document by contentType + id — returns `R2Document \| null` |
+| `listGroups()` | public (RPC) | List all groups/cells — returns `{ groups }` |
+| `listReleases()` | public (RPC) | List creative releases — returns `{ releases }` |
+| `defineTerm(params)` | public (RPC) | Get term definition — returns `{ term, definition }` |
 
 #### Internal Logic
 
-**`fetch` handler — Three-way routing split:**
+**`fetch()` — Three-way routing split:**
 
 ```
 Request URL pathname
-├── /mcp or /mcp/* → handler(request, env, ctx)  (from createMcpHandler)
-├── POST /webhook  → handleWebhook(request, env)
-└── *              → app.fetch(request, env, ctx)  (Hono)
+├── /mcp or /mcp/* → createMcpHandler (per-request, needs this.env)
+├── POST /webhook  → this.handleWebhook(request)
+└── *              → app.fetch(request, this.env, this.ctx)  (Hono)
 ```
 
-1. **MCP path** (`/mcp` or `/mcp/*`): Creates a new `McpServer` via `createMcpServer(env)` and wraps it with `createMcpHandler()`, bypassing Hono. This is critical because MCP uses its own transport (SSE/Streamable HTTP) and CORS configuration.
+1. **MCP path** (`/mcp` or `/mcp/*`): Creates a new `McpServer` via `createMcpServer(this.env)` and wraps it with `createMcpHandler()`, bypassing Hono. Created per-request because `this.env` is unavailable at module scope.
 
-2. **Webhook path** (`POST /webhook`): Delegates to `handleWebhook()` for GitHub push event processing.
+2. **Webhook path** (`POST /webhook`): Delegates to private `handleWebhook()` class method, which has access to `this.ctx.waitUntil()` for fire-and-forget workflow creation.
 
 3. **Everything else**: Goes through Hono, which mounts the REST API at `/api/v1`.
 
-**`queue` handler:**
+**`handleWebhook()` — GitHub push event processing (private class method):**
 
-Set to `handleVectorizeQueue` from `src/consumers/vectorize.ts`. Processes R2 event notifications from the queue.
+1. Verify webhook signature via `x-hub-signature-256` header. Returns 403 if invalid.
+2. Replay protection via delivery ID nonce (24h TTL in KV).
+3. Branch filter: only processes `refs/heads/main`.
+4. Collect changed/deleted `.md` files from all commits, deduplicate.
+5. Fire-and-forget: `this.ctx.waitUntil(SYNC_WORKFLOW.create(...))` — responds immediately.
 
-**Hono app setup:**
+**RPC methods** — thin wrappers over existing retrieval/MCP functions with input validation:
+
+- `searchKnowledge` → validates query (non-empty) and limit (1-20), calls `searchKnowledge()` from retrieval
+- `getDocument` → validates contentType + id required, calls `getDocument()` from retrieval
+- `listGroups` / `listReleases` → no params, delegates to `mcp/tools` helpers
+- `defineTerm` → validates term (non-empty), calls `getTermDefinition()` from `mcp/tools`
+
+**Hono app** (module scope):
 
 ```typescript
 const app = new Hono<{ Bindings: Env }>();
 app.route('/api/v1', api);
 ```
 
-The Hono app is minimal — it only mounts the API sub-application. All middleware (CORS, error handling) is defined within the API module itself.
-
----
-
-**`handleWebhook()` — GitHub push event processing:**
-
-1. **Read body:** `await request.text()` (needed for both signature verification and JSON parsing)
-2. **Verify signature:** Reads `x-hub-signature-256` header, calls `verifyWebhookSignature()`. Returns 403 if invalid.
-3. **Parse payload:** `JSON.parse(body)` as `GitHubPushEvent`
-4. **Branch filter:** Only processes pushes to `refs/heads/main`. Returns `{ status: 'ignored', reason: 'not main branch' }` otherwise.
-5. **Collect files:**
-   - Changed files: flattens `added` + `modified` from all commits, filters for `.md` extension and not excluded
-   - Deleted files: flattens `removed` from all commits, filters for `.md` extension
-   - Note: deleted files are NOT filtered through `isExcluded()` (excluded files that were previously synced should still be deletable)
-6. **Deduplicate:** Uses `Set` to remove duplicates (a file may appear in multiple commits within the same push)
-7. **Short-circuit:** If no markdown files changed, returns `{ status: 'ignored', reason: 'no markdown files changed' }`
-8. **Trigger workflow:** `env.SYNC_WORKFLOW.create({ params: { changedFiles, deletedFiles, commitSha } })`
-9. **Response:** `{ status: 'ok', changed: N, deleted: N }`
+The Hono app is minimal — it only mounts the API sub-application. All middleware (CORS, error handling) is defined within the API module itself. Receives `this.env` and `this.ctx` per-request via `app.fetch()`.
 
 #### Dependencies
-- **Internal:** `./api/routes` (api), `./mcp/server` (createMcpServer), `./consumers/vectorize` (handleVectorizeQueue), `./sync/github` (verifyWebhookSignature, isExcluded), `./types/sync` (GitHubPushEvent), `./sync/workflow` (KnowledgeSyncWorkflow — re-export), `@superbenefit/porch/security` (SECURITY_HEADERS)
-- **External:** `hono` (Hono)
+- **Internal:** `./api/routes` (api), `./mcp/server` (createMcpServer), `./mcp/tools` (listGroups, listReleases, getTermDefinition), `./consumers/vectorize` (handleVectorizeQueue), `./retrieval` (searchKnowledge, getDocument), `./sync/github` (verifyWebhookSignature, isExcluded), `./types/sync` (GitHubPushEvent), `./types/rpc` (RPC param/result types), `./sync/workflow` (KnowledgeSyncWorkflow — re-export), `@superbenefit/porch/security` (SECURITY_HEADERS)
+- **External:** `hono` (Hono), `cloudflare:workers` (WorkerEntrypoint), `agents/mcp` (createMcpHandler)
 
 ---
 
@@ -147,6 +161,12 @@ Both declarations are identical and must be kept in sync. This dual-declaration 
 |------|--------|-------------|
 | `Env` | `env.d.ts` | All Cloudflare bindings |
 | `GitHubPushEvent` | `types/sync.ts` | Webhook payload shape |
+| `SearchKnowledgeParams` | `types/rpc.ts` | RPC search input |
+| `SearchKnowledgeResult` | `types/rpc.ts` | RPC search output |
+| `GetDocumentParams` | `types/rpc.ts` | RPC get document input |
+| `DefineTermParams` | `types/rpc.ts` | RPC define term input |
+| `ListGroupsResult` | `types/rpc.ts` | RPC list groups output |
+| `ListReleasesResult` | `types/rpc.ts` | RPC list releases output |
 
 ## Cloudflare Bindings Used
 
@@ -183,8 +203,9 @@ All bindings are used by this module or the modules it delegates to. See the Com
 | Invalid webhook signature | 403 `Invalid signature` |
 | Non-main branch push | 200 `{ status: 'ignored', reason: 'not main branch' }` |
 | No markdown changes | 200 `{ status: 'ignored', reason: 'no markdown files changed' }` |
-| Workflow creation fails | Exception propagates (500) |
+| Workflow creation fails | Fire-and-forget via `waitUntil` — does not affect response |
 | Unmatched route | Hono's default 404 handler |
+| RPC invalid params | `throw new Error('RPC methodName: ...')` — propagated to caller |
 
 ## Extension Points
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
 /**
  * Main entry point for the SuperBenefit Knowledge Server.
  *
- * Routes:
- * - /api/v1/* — Public REST API (no auth, through Hono)
- * - /mcp, /mcp/* — MCP server (direct to handler, bypasses Hono)
- * - /webhook — GitHub webhook (direct handler)
+ * Extends WorkerEntrypoint to provide:
+ * - HTTP routing: /api/v1/*, /mcp, /webhook
+ * - Queue consumer for Vectorize indexing
+ * - RPC methods for inter-Worker service binding calls
  *
- * Phase 1: No authentication. All tools are Open tier.
+ * Phase 1: No authentication. All tools/RPC are Open tier.
  * Phase 2: Add Access JWT parsing before MCP dispatch.
  */
 
+import { WorkerEntrypoint } from 'cloudflare:workers';
 import { Hono } from 'hono';
 import { createMcpHandler } from 'agents/mcp';
 import { api } from './api/routes';
@@ -17,73 +18,22 @@ import { createMcpServer } from './mcp/server';
 import { handleVectorizeQueue } from './consumers/vectorize';
 import { verifyWebhookSignature, isExcluded } from './sync/github';
 import { SECURITY_HEADERS } from '@superbenefit/porch/security';
+import { searchKnowledge, getDocument } from './retrieval';
+import { listGroups, listReleases, getTermDefinition } from './mcp/tools';
 import type { GitHubPushEvent } from './types/sync';
+import type { SearchFilters, R2Document } from './types';
+import type {
+  SearchKnowledgeParams,
+  SearchKnowledgeResult,
+  GetDocumentParams,
+  DefineTermParams,
+  DefineTermResult,
+  ListGroupsResult,
+  ListReleasesResult,
+} from './types/rpc';
 
 // Re-export workflow class so Cloudflare can discover it via wrangler.jsonc class_name
 export { KnowledgeSyncWorkflow } from './sync/workflow';
-
-// ---------------------------------------------------------------------------
-// Webhook handler
-// ---------------------------------------------------------------------------
-
-async function handleWebhook(request: Request, env: Env): Promise<Response> {
-  const body = await request.text();
-  const signature = request.headers.get('x-hub-signature-256');
-  const deliveryId = request.headers.get('x-github-delivery');
-
-  if (!await verifyWebhookSignature(body, signature, env.GITHUB_WEBHOOK_SECRET)) {
-    return new Response('Invalid signature', { status: 403 });
-  }
-
-  // Security: Replay protection via delivery ID nonce
-  if (deliveryId) {
-    const nonceKey = `webhook:${deliveryId}`;
-    const existing = await env.SYNC_STATE.get(nonceKey);
-    if (existing) {
-      return Response.json({ status: 'duplicate', deliveryId });
-    }
-    // Mark as processed with 24h TTL
-    await env.SYNC_STATE.put(nonceKey, Date.now().toString(), { expirationTtl: 86400 });
-  }
-
-  const payload: GitHubPushEvent = JSON.parse(body);
-
-  // Only process pushes to main branch
-  if (payload.ref !== 'refs/heads/main') {
-    return Response.json({ status: 'ignored', reason: 'not main branch' });
-  }
-
-  // Collect changed and deleted files from all commits
-  const changedFiles = payload.commits
-    .flatMap((c) => [...c.added, ...c.modified])
-    .filter((f) => f.endsWith('.md') && !isExcluded(f));
-  const deletedFiles = payload.commits
-    .flatMap((c) => c.removed)
-    .filter((f) => f.endsWith('.md'));
-
-  // Deduplicate
-  const uniqueChanged = [...new Set(changedFiles)];
-  const uniqueDeleted = [...new Set(deletedFiles)];
-
-  if (uniqueChanged.length === 0 && uniqueDeleted.length === 0) {
-    return Response.json({ status: 'ignored', reason: 'no markdown files changed' });
-  }
-
-  // Trigger sync workflow
-  await env.SYNC_WORKFLOW.create({
-    params: {
-      changedFiles: uniqueChanged,
-      deletedFiles: uniqueDeleted,
-      commitSha: payload.after,
-    },
-  });
-
-  return Response.json({
-    status: 'ok',
-    changed: uniqueChanged.length,
-    deleted: uniqueDeleted.length,
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Hono app — mounts public REST API
@@ -162,16 +112,19 @@ a:hover{border-color:#3f3f46;background:#1f1f23}
 app.route('/api/v1', api);
 
 // ---------------------------------------------------------------------------
-// Export Worker module
+// WorkerEntrypoint — HTTP, queue, and RPC interface
 // ---------------------------------------------------------------------------
 
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+export default class KnowledgeServer extends WorkerEntrypoint<Env> {
+  /**
+   * HTTP request handler — rate limiting, routing split.
+   */
+  async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
 
     // Rate limiting — key on client IP
     const clientIp = request.headers.get('CF-Connecting-IP') ?? 'unknown';
-    const { success } = await env.RATE_LIMITER.limit({ key: clientIp });
+    const { success } = await this.env.RATE_LIMITER.limit({ key: clientIp });
     if (!success) {
       return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
         status: 429,
@@ -179,9 +132,9 @@ export default {
       });
     }
 
-    // MCP server — direct to handler, bypassing Hono
+    // MCP server — created per-request (WorkerEntrypoint: this.env unavailable at module scope)
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
-      const server = createMcpServer(env);
+      const server = createMcpServer(this.env);
       const handler = createMcpHandler(server, {
         route: '/mcp',
         corsOptions: {
@@ -191,7 +144,7 @@ export default {
           headers: 'Content-Type, Accept, Authorization, Mcp-Session-Id',
         },
       });
-      const response = await handler(request, env, ctx);
+      const response = await handler(request, this.env, this.ctx);
 
       // Inject security headers into MCP response
       const securedResponse = new Response(response.body, response);
@@ -203,11 +156,146 @@ export default {
 
     // GitHub webhook
     if (url.pathname === '/webhook' && request.method === 'POST') {
-      return handleWebhook(request, env);
+      return this.handleWebhook(request);
     }
 
     // Everything else through Hono (REST API, health checks)
-    return app.fetch(request, env, ctx);
-  },
-  queue: handleVectorizeQueue,
-};
+    return app.fetch(request, this.env, this.ctx);
+  }
+
+  /**
+   * Queue consumer — processes R2 event notifications for Vectorize indexing.
+   */
+  async queue(batch: MessageBatch<unknown>): Promise<void> {
+    return handleVectorizeQueue(batch, this.env);
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhook handler — private, uses this.env and this.ctx
+  // -------------------------------------------------------------------------
+
+  private async handleWebhook(request: Request): Promise<Response> {
+    const body = await request.text();
+    const signature = request.headers.get('x-hub-signature-256');
+    const deliveryId = request.headers.get('x-github-delivery');
+
+    if (!await verifyWebhookSignature(body, signature, this.env.GITHUB_WEBHOOK_SECRET)) {
+      return new Response('Invalid signature', { status: 403 });
+    }
+
+    // Security: Replay protection via delivery ID nonce
+    if (deliveryId) {
+      const nonceKey = `webhook:${deliveryId}`;
+      const existing = await this.env.SYNC_STATE.get(nonceKey);
+      if (existing) {
+        return Response.json({ status: 'duplicate', deliveryId });
+      }
+      // Mark as processed with 24h TTL
+      await this.env.SYNC_STATE.put(nonceKey, Date.now().toString(), { expirationTtl: 86400 });
+    }
+
+    const payload: GitHubPushEvent = JSON.parse(body);
+
+    // Only process pushes to main branch
+    if (payload.ref !== 'refs/heads/main') {
+      return Response.json({ status: 'ignored', reason: 'not main branch' });
+    }
+
+    // Collect changed and deleted files from all commits
+    const changedFiles = payload.commits
+      .flatMap((c) => [...c.added, ...c.modified])
+      .filter((f) => f.endsWith('.md') && !isExcluded(f));
+    const deletedFiles = payload.commits
+      .flatMap((c) => c.removed)
+      .filter((f) => f.endsWith('.md'));
+
+    // Deduplicate
+    const uniqueChanged = [...new Set(changedFiles)];
+    const uniqueDeleted = [...new Set(deletedFiles)];
+
+    if (uniqueChanged.length === 0 && uniqueDeleted.length === 0) {
+      return Response.json({ status: 'ignored', reason: 'no markdown files changed' });
+    }
+
+    // Fire-and-forget workflow — respond immediately
+    this.ctx.waitUntil(
+      this.env.SYNC_WORKFLOW.create({
+        params: {
+          changedFiles: uniqueChanged,
+          deletedFiles: uniqueDeleted,
+          commitSha: payload.after,
+        },
+      })
+    );
+
+    return Response.json({
+      status: 'ok',
+      changed: uniqueChanged.length,
+      deleted: uniqueDeleted.length,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // RPC methods — callable via service bindings from other Workers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Search the knowledge base using three-stage retrieval pipeline.
+   * Stage 1: Vectorize similarity search → Stage 2: BGE reranker → results
+   */
+  async searchKnowledge(params: SearchKnowledgeParams): Promise<SearchKnowledgeResult> {
+    if (!params?.query || typeof params.query !== 'string' || params.query.trim() === '') {
+      throw new Error('RPC searchKnowledge: query is required');
+    }
+    if (params.limit !== undefined && (params.limit < 1 || params.limit > 20)) {
+      throw new Error('RPC searchKnowledge: limit must be 1-20');
+    }
+
+    const filters: SearchFilters = {};
+    if (params.contentType) filters.contentType = params.contentType;
+    if (params.group) filters.group = params.group;
+    if (params.release) filters.release = params.release;
+
+    const items = await searchKnowledge(params.query, filters, {}, this.env);
+    const limited = params.limit ? items.slice(0, params.limit) : items;
+    return { items: limited, total: items.length };
+  }
+
+  /**
+   * Get a single document by content type and ID.
+   * Returns null if not found.
+   */
+  async getDocument(params: GetDocumentParams): Promise<R2Document | null> {
+    if (!params?.contentType || !params?.id) {
+      throw new Error('RPC getDocument: contentType and id are required');
+    }
+    return getDocument(params.contentType, params.id, this.env);
+  }
+
+  /**
+   * List all groups/cells in the SuperBenefit ecosystem.
+   */
+  async listGroups(): Promise<ListGroupsResult> {
+    const groups = await listGroups(this.env);
+    return { groups };
+  }
+
+  /**
+   * List all creative releases with metadata.
+   */
+  async listReleases(): Promise<ListReleasesResult> {
+    const releases = await listReleases(this.env);
+    return { releases };
+  }
+
+  /**
+   * Get the definition of a term from the SuperBenefit lexicon.
+   */
+  async defineTerm(params: DefineTermParams): Promise<DefineTermResult> {
+    if (!params?.term || typeof params.term !== 'string' || params.term.trim() === '') {
+      throw new Error('RPC defineTerm: term is required');
+    }
+    const definition = await getTermDefinition(params.term, this.env);
+    return { term: params.term, definition };
+  }
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -410,5 +410,5 @@ export function registerTools(server: McpServer, env: Env): void {
   );
 }
 
-// Export helper functions for use in resources
-export { listGroups, listReleases };
+// Export helper functions for use in resources and RPC methods
+export { listGroups, listReleases, getTermDefinition };

--- a/src/sync/workflow.ts
+++ b/src/sync/workflow.ts
@@ -107,12 +107,19 @@ export class KnowledgeSyncWorkflow extends WorkflowEntrypoint<Env, SyncParams> {
 
     // Process deleted files
     for (const filePath of deletedFiles) {
-      await step.do(`delete-${filePath}`, async () => {
-        const contentType = inferContentType(filePath);
-        const id = generateId(filePath);
-        await this.env.KNOWLEDGE.delete(toR2Key(contentType, id));
-        console.log(`Deleted ${filePath} (${contentType}/${id}) — removed from Git`);
-      });
+      await step.do(
+        `delete-${filePath}`,
+        {
+          retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' },
+          timeout: '30 seconds',
+        },
+        async () => {
+          const contentType = inferContentType(filePath);
+          const id = generateId(filePath);
+          await this.env.KNOWLEDGE.delete(toR2Key(contentType, id));
+          console.log(`Deleted ${filePath} (${contentType}/${id}) — removed from Git`);
+        },
+      );
     }
   }
 }

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -3,7 +3,7 @@
 > Defines the entire type system: 21-type content ontology, auth model, API shapes, storage schemas, and sync payloads.
 
 **Source:** `src/types/`
-**Files:** 5 (`index.ts`, `content.ts`, `api.ts`, `storage.ts`, `sync.ts`) + auth types re-exported from `@superbenefit/porch/auth`
+**Files:** 6 (`index.ts`, `content.ts`, `api.ts`, `storage.ts`, `sync.ts`, `rpc.ts`) + auth types re-exported from `@superbenefit/porch/auth`
 **Spec reference:** `docs/spec.md` sections 2, 3, 4, 5, 6, 8
 **Depends on:** none (leaf module)
 **Depended on by:** `auth`, `retrieval`, `consumers`, `sync`, `mcp`, `api`, `index`
@@ -64,6 +64,7 @@ All exports are re-exports. Organized into sections by spec reference:
 | API (spec 6, 8) | `SearchFiltersSchema`, `ListParamsSchema`, `SearchParamsSchema`, `SearchResultSchema`, `RerankResultSchema`, `ErrorResponseSchema`, `EntryResponseSchema`, `EntryListResponseSchema`, `SearchResponseSchema` | `SearchFilters`, `ListParams`, `SearchParams`, `SearchResult`, `RerankResult`, `ErrorResponse` | |
 | Storage (spec 4) | `R2DocumentSchema`, `VectorizeMetadataSchema` | `R2Document`, `VectorizeMetadata` | `truncateForMetadata`, `generateId`, `toR2Key`, `extractIdFromKey`, `extractContentTypeFromKey`, `VECTORIZE_LIMITS`, `VECTORIZE_NAMESPACE` |
 | Sync (spec 5) | `SyncParamsSchema` | `SyncParams`, `R2EventNotification`, `GitHubPushEvent`, `ParsedMarkdown` | |
+| RPC (spec v0.17) | | `SearchKnowledgeParams`, `SearchKnowledgeResult`, `GetDocumentParams`, `DefineTermParams`, `DefineTermResult`, `ListGroupsResult`, `ListReleasesResult` | |
 
 #### Dependencies
 - **Internal:** `./content`, `@superbenefit/porch/auth`, `./api`, `./storage`, `./sync`
@@ -315,6 +316,34 @@ The `SearchFiltersSchema` is shared between REST API and MCP tools — both use 
 
 #### Dependencies
 - **External:** `@hono/zod-openapi`
+
+---
+
+### `rpc.ts`
+
+**Purpose:** Defines RPC parameter and result types for the WorkerEntrypoint service binding interface. Consumer apps import these for type-safe method calls.
+
+#### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `SearchKnowledgeParams` | Interface | `{ query, contentType?, group?, release?, limit? }` |
+| `SearchKnowledgeResult` | Interface | `{ items: SearchResult[], total: number }` |
+| `GetDocumentParams` | Interface | `{ contentType, id }` |
+| `DefineTermParams` | Interface | `{ term }` |
+| `DefineTermResult` | Interface | `{ term, definition: string \| null }` |
+| `ListGroupsResult` | Interface | `{ groups: Array<{ id, title, description? }> }` |
+| `ListReleasesResult` | Interface | `{ releases: Array<{ id, title, description? }> }` |
+| `ContentType` | Re-export | From `./content` |
+| `SearchResult` | Re-export | From `./api` |
+| `R2Document` | Re-export | From `./storage` |
+
+#### Internal Logic
+
+These types define the contract for inter-Worker RPC calls via service bindings. They reuse existing entity types (`ContentType`, `SearchResult`, `R2Document`) rather than duplicating them. Exposed via `package.json` exports field: `import type { SearchKnowledgeParams } from 'superbenefit-knowledge-server/types'`.
+
+#### Dependencies
+- **Internal:** `./content` (ContentType), `./api` (SearchResult), `./storage` (R2Document)
 
 ---
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,3 +105,14 @@ export type { R2Document, VectorizeMetadata } from './storage';
 // Sync (spec section 5)
 export { SyncParamsSchema } from './sync';
 export type { SyncParams, R2EventNotification, GitHubPushEvent, ParsedMarkdown } from './sync';
+
+// RPC (spec v0.17)
+export type {
+  SearchKnowledgeParams,
+  SearchKnowledgeResult,
+  GetDocumentParams,
+  DefineTermParams,
+  DefineTermResult,
+  ListGroupsResult,
+  ListReleasesResult,
+} from './rpc';

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -1,0 +1,59 @@
+/**
+ * RPC type definitions for WorkerEntrypoint service binding interface.
+ *
+ * These types define the contract for inter-Worker RPC calls via service bindings.
+ * Consumer apps import these for type-safe method calls:
+ *   import type { SearchKnowledgeParams } from 'superbenefit-knowledge-server/types'
+ *
+ * Spec: tmp/worker-rpc.md v0.17
+ */
+
+import type { ContentType } from './content';
+import type { SearchResult } from './api';
+import type { R2Document } from './storage';
+
+// ---------------------------------------------------------------------------
+// Parameter types
+// ---------------------------------------------------------------------------
+
+export interface SearchKnowledgeParams {
+  query: string;
+  contentType?: ContentType;
+  group?: string;
+  release?: string;
+  limit?: number;
+}
+
+export interface GetDocumentParams {
+  contentType: ContentType;
+  id: string;
+}
+
+export interface DefineTermParams {
+  term: string;
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export interface SearchKnowledgeResult {
+  items: SearchResult[];
+  total: number;
+}
+
+export interface ListGroupsResult {
+  groups: Array<{ id: string; title: string; description?: string }>;
+}
+
+export interface ListReleasesResult {
+  releases: Array<{ id: string; title: string; description?: string }>;
+}
+
+export interface DefineTermResult {
+  term: string;
+  definition: string | null;
+}
+
+// Re-export entity types that consumers need
+export type { ContentType, SearchResult, R2Document };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -53,6 +53,10 @@
 		}
 	],
 	"queues": {
+		// R2 event notifications feed this queue but must be configured externally:
+		// npx wrangler r2 bucket notification create superbenefit-knowledge \
+		//   --event-type object-create --event-type object-delete \
+		//   --queue superbenefit-knowledge-sync
 		"consumers": [
 			{
 				"queue": "superbenefit-knowledge-sync",


### PR DESCRIPTION
## Summary

- Convert default export to `WorkerEntrypoint<Env>` class enabling zero-latency inter-Worker RPC calls via Cloudflare service bindings
- Add 5 read-only RPC methods (`searchKnowledge`, `getDocument`, `listGroups`, `listReleases`, `defineTerm`) with input validation
- Move `handleWebhook` into class as private method with `ctx.waitUntil()` for fire-and-forget workflow creation
- Add explicit retry config to workflow delete steps
- Create `src/types/rpc.ts` with RPC parameter/result types, exposed via `package.json` exports
- Update all relevant documentation (CLAUDE.md, README.md, src/README.md, src/types/README.md)

### Files changed (11)

| File | Change |
|------|--------|
| `src/index.ts` | WorkerEntrypoint class, private webhook handler, 5 RPC methods |
| `src/types/rpc.ts` | **New** — RPC type definitions |
| `src/types/index.ts` | Re-export RPC types |
| `src/mcp/tools.ts` | Export `getTermDefinition` |
| `src/sync/workflow.ts` | Add retry config to delete steps |
| `package.json` | Add `./types` export path |
| `wrangler.jsonc` | Document R2 event notification dependency |
| `CLAUDE.md` | Update for WorkerEntrypoint pattern |
| `README.md` | Update architecture diagram, project structure |
| `src/README.md` | Rewrite for WorkerEntrypoint class |
| `src/types/README.md` | Add rpc.ts documentation |

### Validation

- cf-validator: 30 pass, 0 fail, 0 warnings (all resolved)
- `npm run type-check`: pass
- `npm run test`: 63/63 pass
- Dev server: health, search, entries, MCP init, CORS all verified

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run test` — all 63 tests pass
- [ ] `npm run dev` — server starts, all HTTP endpoints work
- [ ] MCP Inspector connects and lists tools at `/mcp`
- [ ] `curl /api/v1/health` returns 200
- [ ] Landing page renders at `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)