### PR TITLE
feat: add path-based query capabilities

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -97,7 +97,7 @@ const listEntriesRoute = createRoute({
 });
 
 api.openapi(listEntriesRoute, async (c) => {
-  const { contentType, group, release, limit, offset } = c.req.valid('query');
+  const { contentType, group, release, sourcePath, limit, offset } = c.req.valid('query');
 
   // Build R2 list prefix based on contentType filter
   const prefix = contentType ? `content/${contentType}/` : 'content/';
@@ -122,7 +122,7 @@ api.openapi(listEntriesRoute, async (c) => {
   let paginated: R2Document[];
   let total: number;
 
-  if (group || release) {
+  if (group || release || sourcePath) {
     // Need metadata to filter — fetch in batches of 50 to limit concurrency
     const BATCH_SIZE = 50;
     const allDocs: R2Document[] = [];
@@ -139,6 +139,7 @@ api.openapi(listEntriesRoute, async (c) => {
         if (!doc) continue;
         if (group && doc.metadata?.group !== group) continue;
         if (release && doc.metadata?.release !== release) continue;
+        if (sourcePath && !doc.path.startsWith(sourcePath)) continue;
         allDocs.push(doc);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { createMcpServer } from './mcp/server';
 import { handleVectorizeQueue } from './consumers/vectorize';
 import { verifyWebhookSignature, isExcluded } from './sync/github';
 import { SECURITY_HEADERS } from '@superbenefit/porch/security';
-import { searchKnowledge, getDocument } from './retrieval';
+import { searchKnowledge, getDocument, getDocumentByPath } from './retrieval';
 import { listGroups, listReleases, getTermDefinition } from './mcp/tools';
 import type { GitHubPushEvent } from './types/sync';
 import type { SearchFilters, R2Document } from './types';
@@ -26,6 +26,7 @@ import type {
   SearchKnowledgeParams,
   SearchKnowledgeResult,
   GetDocumentParams,
+  GetDocumentByPathParams,
   DefineTermParams,
   DefineTermResult,
   ListGroupsResult,
@@ -270,6 +271,17 @@ export default class KnowledgeServer extends WorkerEntrypoint<Env> {
       throw new Error('RPC getDocument: contentType and id are required');
     }
     return getDocument(params.contentType, params.id, this.env);
+  }
+
+  /**
+   * Get a single document by its exact source path.
+   * Returns null if not found.
+   */
+  async getDocumentByPath(params: GetDocumentByPathParams): Promise<R2Document | null> {
+    if (!params?.path || typeof params.path !== 'string' || params.path.trim() === '') {
+      throw new Error('RPC getDocumentByPath: path is required');
+    }
+    return getDocumentByPath(params.path, this.env);
   }
 
   /**

--- a/src/retrieval/fetch.ts
+++ b/src/retrieval/fetch.ts
@@ -45,3 +45,41 @@ export async function getDocument(
   if (!obj) return null;
   return obj.json();
 }
+
+/**
+ * Find a single document by its exact source path.
+ * Scans all R2 content keys and returns the first match.
+ *
+ * @param path - The exact source path to match (e.g. "docs/governance.md")
+ * @param env - Cloudflare Worker environment bindings
+ * @returns The R2Document or null if not found
+ */
+export async function getDocumentByPath(
+  path: string,
+  env: Env,
+): Promise<R2Document | null> {
+  const prefix = 'content/';
+  const allObjects: R2Object[] = [];
+  let cursor: string | undefined;
+  do {
+    const listed = await env.KNOWLEDGE.list({ prefix, limit: 1000, ...(cursor ? { cursor } : {}) });
+    allObjects.push(...listed.objects);
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  const BATCH_SIZE = 50;
+  for (let i = 0; i < allObjects.length; i += BATCH_SIZE) {
+    const batch = allObjects.slice(i, i + BATCH_SIZE);
+    const docs = await Promise.all(
+      batch.map(async (obj): Promise<R2Document | null> => {
+        const object = await env.KNOWLEDGE.get(obj.key);
+        if (!object) return null;
+        return object.json();
+      }),
+    );
+    for (const doc of docs) {
+      if (doc && doc.path === path) return doc;
+    }
+  }
+  return null;
+}

--- a/src/retrieval/index.ts
+++ b/src/retrieval/index.ts
@@ -1,6 +1,6 @@
 export { searchWithFilters, generateEmbedding } from './search';
 export { rerankResults, hashQuery } from './rerank';
-export { getDocuments, getDocument } from './fetch';
+export { getDocuments, getDocument, getDocumentByPath } from './fetch';
 
 import type { SearchFilters, SearchResult, R2Document } from '../types';
 import type { ContentType } from '../types';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -19,6 +19,7 @@ export const ListParamsSchema = z
     contentType: ContentTypeSchema.optional(),
     group: z.string().optional(),
     release: z.string().optional(),
+    sourcePath: z.string().optional(),
     limit: z.coerce.number().min(1).max(100).default(20),
     offset: z.coerce.number().min(0).default(0),
   })

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -29,6 +29,10 @@ export interface GetDocumentParams {
   id: string;
 }
 
+export interface GetDocumentByPathParams {
+  path: string;
+}
+
 export interface DefineTermParams {
   term: string;
 }


### PR DESCRIPTION
## Summary
- Add `sourcePath` query param to `GET /api/v1/entries` for prefix-matching on document source paths (e.g. `?sourcePath=docs/`)
- Add `getDocumentByPath` RPC method for exact path lookups via service bindings
- Add `GetDocumentByPathParams` type to RPC interface

## Test plan
- [ ] `npm run type-check` passes
- [ ] `GET /api/v1/entries?sourcePath=docs/` returns only docs-prefixed documents
- [ ] `GET /api/v1/entries?sourcePath=docs/&contentType=article` intersects both filters
- [ ] `GET /api/v1/entries` (no sourcePath) behaves unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)