### PR TITLE
feat: add indexKeys to content manifest

### DIFF
--- a/src/sync/workflow.ts
+++ b/src/sync/workflow.ts
@@ -187,23 +187,29 @@ export class KnowledgeSyncWorkflow extends WorkflowEntrypoint<Env, SyncParams> {
           return keys;
         }
 
-        const [keys, attachmentKeys] = await Promise.all([
+        const MANIFEST_KEY = 'indexes/all-content.json';
+        const [keys, indexKeys, attachmentKeys] = await Promise.all([
           listPrefix(this.env.KNOWLEDGE, 'content/'),
+          listPrefix(this.env.KNOWLEDGE, 'indexes/').then((k) =>
+            k.filter((key) => key !== MANIFEST_KEY),
+          ),
           listPrefix(this.env.KNOWLEDGE, 'attachments/'),
         ]);
 
         const manifest: R2Document = {
           id: 'all-content',
           contentType: 'index',
-          path: 'indexes/all-content.json',
-          metadata: { keys, attachmentKeys },
+          path: MANIFEST_KEY,
+          metadata: { keys, indexKeys, attachmentKeys },
           content: '',
           syncedAt: new Date().toISOString(),
           commitSha,
         };
 
-        await this.env.KNOWLEDGE.put('indexes/all-content.json', JSON.stringify(manifest));
-        console.log(`Manifest written: ${keys.length} content keys, ${attachmentKeys.length} attachment keys`);
+        await this.env.KNOWLEDGE.put(MANIFEST_KEY, JSON.stringify(manifest));
+        console.log(
+          `Manifest written: ${keys.length} content keys, ${indexKeys.length} index keys, ${attachmentKeys.length} attachment keys`,
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

- Extends the `indexes/all-content.json` manifest to include a third key array: `indexKeys`
- Lists all `indexes/` prefix objects (folder index metadata) excluding the manifest itself
- The manifest now has `metadata.{ keys, indexKeys, attachmentKeys }` — giving the garden loader everything it needs to discover all content types with zero credentials

## Why

The garden loader only consumed `metadata.keys` (content/ prefix), missing all folder index metadata stored under `indexes/`. This PR makes the manifest the single source of truth for all R2 content.

## Test plan

- [ ] Trigger a webhook push or bootstrap sync
- [ ] Fetch `https://knowledge-bucket.superbenefit.dev/indexes/all-content.json` and confirm `metadata.indexKeys` is present and non-empty
- [ ] Confirm `indexes/all-content.json` is NOT in `indexKeys` (self-reference excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)